### PR TITLE
Fix  a redefinition error in the YOLO8.hpp

### DIFF
--- a/include/YOLO8.hpp
+++ b/include/YOLO8.hpp
@@ -618,35 +618,6 @@ namespace utils
 
         DEBUG_PRINT("Bounding boxes and masks drawn on image.");
     }
-
-    /**
-     * @brief A robust implementation of a clamp function.
-     *        Restricts a value to lie within a specified range [low, high].
-     *
-     * @tparam T The type of the value to clamp. Should be an arithmetic type (int, float, etc.).
-     * @param value The value to clamp.
-     * @param low The lower bound of the range.
-     * @param high The upper bound of the range.
-     * @return const T& The clamped value, constrained to the range [low, high].
-     *
-     * @note If low > high, the function swaps the bounds automatically to ensure valid behavior.
-     */
-    template <typename T>
-    typename std::enable_if<std::is_arithmetic<T>::value, T>::type
-    inline clamp(const T &value, const T &low, const T &high)
-    {
-        // Ensure the range [low, high] is valid; swap if necessary
-        T validLow = low < high ? low : high;
-        T validHigh = low < high ? high : low;
-
-        // Clamp the value to the range [validLow, validHigh]
-        if (value < validLow)
-            return validLow;
-        if (value > validHigh)
-            return validHigh;
-        return value;
-    }
-
 };
 
 /**


### PR DESCRIPTION
Testing the yolov8 model, I found this error during the build process
![Screenshot from 2025-01-27 17-57-22](https://github.com/user-attachments/assets/b0a9cd04-3d76-49a0-b828-e4392695d3b3)

And the problem was that the clamp function is implemented twice at the top and the end of the utils class, so I removed the one at the end and it builds successfully

![Screenshot from 2025-01-27 17-57-36](https://github.com/user-attachments/assets/77beeba8-bc0d-4221-9ea6-3b70b869fc62)


![Screenshot from 2025-01-27 17-58-50](https://github.com/user-attachments/assets/88b73887-ffe8-4055-895c-2c94a5d3cdef)
