### PR TITLE
Fix yolo 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,14 @@
 
 ## Overview
 
-**YOLOs-CPP** provides single c++ headers with high-performance application designed for real-time object detection and segmentation using various YOLO (You Only Look Once) models from [Ultralytics](https://github.com/ultralytics/ultralytics). Leveraging the power of [ONNX Runtime](https://github.com/microsoft/onnxruntime) and [OpenCV](https://opencv.org/), this project provides seamless integration with unified YOLOv(5,7,8,10,11) implementation for image, video, and live camera inference. Whether you're developing for research, production, or hobbyist projects, this application offers flexibility and efficiency.
+**YOLOs-CPP** provides single c++ headers with high-performance application designed for real-time object detection and segmentation using various YOLO (You Only Look Once) models from [Ultralytics](https://github.com/ultralytics/ultralytics). Leveraging the power of [ONNX Runtime](https://github.com/microsoft/onnxruntime) and [OpenCV](https://opencv.org/), this project provides seamless integration with unified YOLOv(5,7,8,9,10,11) implementation for image, video, and live camera inference. Whether you're developing for research, production, or hobbyist projects, this application offers flexibility and efficiency.
 
 
 ## News 
 
 #### 📌 Pinned
+
+* [2025.01.29] 🎯🎯🎯 YOLOs-CPP now supports YOLOv9 for object detection. Thanks to [Mohamed Samir](https://github.com/mohamedsamirx).
 
 * [2025.01.26] 🔥🔥🔥  YOLOS-CPP Provide now segmentation headers for YOLOv8 and YOLOv11 also quantized models.
 
@@ -128,7 +130,7 @@ int main()
 ## Features
 
 
-- **Multiple YOLO Models**: Supports YOLOv5, YOLOv7, YOLOv8, YOLOv10, and YOLOv11 with standard and quantized ONNX models for flexibility in use cases.
+- **Multiple YOLO Models**: Supports YOLOv5, YOLOv7, YOLOv8, YOLOv9, YOLOv10, and YOLOv11 with standard and quantized ONNX models for flexibility in use cases.
   
 - **ONNX Runtime Integration**: Leverages ONNX Runtime for optimized inference on both CPU and GPU, ensuring high performance.
   - **Dynamic Shapes Handling**: Adapts automatically to varying input sizes for improved versatility.
@@ -222,11 +224,6 @@ To perform object detection on a video file:
 ./run_video.sh 
 ```
 
-**Example:**
-```bash
-./run_video.sh 
-```
-
 The above command will process [SIG_experience_center.mp4](data/SIG_experience_center.mp4) using the YOLO11n model and save the output video with detected objects.
 
 #### Run Camera Inference
@@ -250,6 +247,7 @@ The project includes various pertained standard YOLO models stored in the `model
 |                  | yolo7-tiny.onnx            |
 |                  | yolo8n.onnx                |
 |                  | yolo8n-seg.onnx                |
+|                  | yolov9s.onnx               |
 |                  | yolo10n.onnx               |
 |                  | yolo11n.onnx               |
 |                  | yolo11n-seg.onnx               |

--- a/include/YOLO9.hpp
+++ b/include/YOLO9.hpp
@@ -1,0 +1,759 @@
+#pragma once
+
+// ===================================
+// Single YOLOv9 Detector Header File
+// ===================================
+//
+// This header defines the YOLO9Detector class for performing object detection using the YOLOv9 model.
+// It includes necessary libraries, utility structures, and helper functions to facilitate model inference
+// and result postprocessing.
+//
+// Author: Mohamed Samir, https://www.linkedin.com/in/mohamed-samir-7a730b237/
+// Date: 29.01.2025
+//
+// ================================
+
+/**
+ * @file YOLO9Detector.hpp
+ * @brief Header file for the YOLO9Detector class, responsible for object detection
+ *        using the YOLOv9 model with optimized performance for minimal latency.
+ */
+
+
+// Include necessary ONNX Runtime and OpenCV headers
+#include <onnxruntime_cxx_api.h>
+#include <opencv2/opencv.hpp>
+
+// Include standard libraries for various utilities
+#include <vector>
+#include <string>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <chrono>
+#include <random>
+#include <memory>
+#include <thread>
+
+
+// Include debug and custom ScopedTimer tools for performance measurement
+#include "tools/Debug.hpp"
+#include "tools/ScopedTimer.hpp"
+
+/**
+ * @brief Confidence threshold for filtering detections.
+ */
+const float CONFIDENCE_THRESHOLD = 0.45f;
+
+/**
+ * @brief Confidence threshold for filtering detections.
+ */
+const float NMS_THRESHOLD = 0.4f;
+
+
+
+/**
+ * @brief Struct to represent a single detection with bounding box.
+ */
+struct Detection {
+    int x1, y1, x2, y2;   // Coordinates of the bounding box
+    int class_id;         // Object class ID
+    float confidence;     // Confidence score of the detection
+
+    // Constructor to initialize all members
+    Detection(int x1, int y1, int x2, int y2, int class_id, float confidence)
+        : x1(x1), y1(y1), x2(x2), y2(y2), class_id(class_id), confidence(confidence) {}
+};
+
+/**
+ * @namespace utils
+ * @brief Namespace containing utility functions for the YOLO9Detector.
+ */
+namespace utils {
+    /**
+     * @brief Loads class names from a given file path.
+     * 
+     * @param path Path to the file containing class names.
+     * @return std::vector<std::string> Vector of class names.
+     */
+    std::vector<std::string> getClassNames(const std::string &path) {
+        std::vector<std::string> classNames;
+        std::ifstream infile(path);
+
+        if (infile) {
+            std::string line;
+            while (getline(infile, line)) {
+                // Remove carriage return if present (for Windows compatibility)
+                if (!line.empty() && line.back() == '\r')
+                    line.pop_back();
+                classNames.emplace_back(line);
+            }
+        } else {
+            std::cerr << "ERROR: Failed to access class name path: " << path << std::endl;
+        }
+
+        DEBUG_PRINT("Loaded class names from " + path);
+        return classNames;
+    }
+
+    /**
+     * @brief Computes the product of elements in a vector.
+     * 
+     * @param vector Vector of integers.
+     * @return size_t Product of all elements.
+     */
+    size_t vectorProduct(const std::vector<int64_t> &vector) {
+        return std::accumulate(vector.begin(), vector.end(), 1ull, std::multiplies<size_t>());
+    }
+    
+    /**
+     * @brief Resizes an image with letterboxing to maintain aspect ratio.
+     * 
+     * @param image Input image.
+     * @param outImage Output resized and padded image.
+     * @param newShape Desired output size.
+     * @param color Padding color (default is gray).
+     * @param auto_ Automatically adjust padding to be multiple of stride.
+     * @param scaleFill Whether to scale to fill the new shape without keeping aspect ratio.
+     * @param scaleUp Whether to allow scaling up of the image.
+     * @param stride Stride size for padding alignment.
+     */
+    inline void letterBox(const cv::Mat& image, cv::Mat& outImage,
+                        const cv::Size& newShape,
+                        const cv::Scalar& color = cv::Scalar(114, 114, 114),
+                        bool auto_ = true,
+                        bool scaleFill = false,
+                        bool scaleUp = true,
+                        int stride = 32) {
+        // Calculate the scaling ratio to fit the image within the new shape
+        float ratio = std::min(static_cast<float>(newShape.height) / image.rows,
+                            static_cast<float>(newShape.width) / image.cols);
+
+        // Prevent scaling up if not allowed
+        if (!scaleUp) {
+            ratio = std::min(ratio, 1.0f);
+        }
+
+        // Calculate new dimensions after scaling
+        int newUnpadW = static_cast<int>(std::round(image.cols * ratio));
+        int newUnpadH = static_cast<int>(std::round(image.rows * ratio));
+
+        // Calculate padding needed to reach the desired shape
+        int dw = newShape.width - newUnpadW;
+        int dh = newShape.height - newUnpadH;
+
+        if (auto_) {
+            // Ensure padding is a multiple of stride for model compatibility
+            dw = (dw % stride) / 2;
+            dh = (dh % stride) / 2;
+        } else if (scaleFill) {
+            // Scale to fill without maintaining aspect ratio
+            newUnpadW = newShape.width;
+            newUnpadH = newShape.height;
+            ratio = std::min(static_cast<float>(newShape.width) / image.cols,
+                            static_cast<float>(newShape.height) / image.rows);
+            dw = 0;
+            dh = 0;
+        } else {
+            // Evenly distribute padding on both sides
+            // Calculate separate padding for left/right and top/bottom to handle odd padding
+            int padLeft = dw / 2;
+            int padRight = dw - padLeft;
+            int padTop = dh / 2;
+            int padBottom = dh - padTop;
+
+            // Resize the image if the new dimensions differ
+            if (image.cols != newUnpadW || image.rows != newUnpadH) {
+                cv::resize(image, outImage, cv::Size(newUnpadW, newUnpadH), 0, 0, cv::INTER_LINEAR);
+            } else {
+                // Avoid unnecessary copying if dimensions are the same
+                outImage = image;
+            }
+
+            // Apply padding to reach the desired shape
+            cv::copyMakeBorder(outImage, outImage, padTop, padBottom, padLeft, padRight, cv::BORDER_CONSTANT, color);
+            return; // Exit early since padding is already applied
+        }
+
+        // Resize the image if the new dimensions differ
+        if (image.cols != newUnpadW || image.rows != newUnpadH) {
+            cv::resize(image, outImage, cv::Size(newUnpadW, newUnpadH), 0, 0, cv::INTER_LINEAR);
+        } else {
+            // Avoid unnecessary copying if dimensions are the same
+            outImage = image;
+        }
+
+        // Calculate separate padding for left/right and top/bottom to handle odd padding
+        int padLeft = dw / 2;
+        int padRight = dw - padLeft;
+        int padTop = dh / 2;
+        int padBottom = dh - padTop;
+
+        // Apply padding to reach the desired shape
+        cv::copyMakeBorder(outImage, outImage, padTop, padBottom, padLeft, padRight, cv::BORDER_CONSTANT, color);
+    }
+
+
+    /**
+     * @brief Scales detection coordinates back to the original image size.
+     * 
+     * @param imageShape Shape of the resized image used for inference.
+     * @param bbox Detection bounding box to be scaled.
+     * @param imageOriginalShape Original image size before resizing.
+     */
+    void scaleResultCoordsToOriginal(const cv::Size &imageShape, Detection &bbox, const cv::Size &imageOriginalShape) {
+        // Calculate the scaling factor used during preprocessing
+        float gain = std::min(static_cast<float>(imageShape.width) / static_cast<float>(imageOriginalShape.width),
+                              static_cast<float>(imageShape.height) / static_cast<float>(imageOriginalShape.height));
+
+        // Calculate padding added during preprocessing
+        int padX = static_cast<int>((imageShape.width - imageOriginalShape.width * gain) / 2.0f);
+        int padY = static_cast<int>((imageShape.height - imageOriginalShape.height * gain) / 2.0f);
+
+        // Adjust bounding box coordinates by removing padding and scaling
+        bbox.x1 = static_cast<int>((bbox.x1 - padX) / gain);
+        bbox.y1 = static_cast<int>((bbox.y1 - padY) / gain);
+        bbox.x2 = static_cast<int>((bbox.x2 - padX) / gain);
+        bbox.y2 = static_cast<int>((bbox.y2 - padY) / gain);
+    }
+
+    /**
+     * @brief Draws bounding boxes and labels on the image based on detections.
+     * 
+     * @param image Image on which to draw.
+     * @param detectionVector Vector of detections.
+     * @param classNames Vector of class names corresponding to object IDs.
+     * @param colors Vector of colors for each class.
+     */
+    inline void drawBoundingBox(cv::Mat &image, std::vector<Detection> &detectionVector, const std::vector<std::string> &classNames, const std::vector<cv::Scalar>& colors) {
+        // Precompute the number of detections to iterate efficiently
+        size_t numDetections = detectionVector.size();
+
+        // Iterate through each detection to draw bounding boxes and labels
+        for (size_t i = 0; i < numDetections; ++i) {
+            const auto& detection = detectionVector[i];
+
+            // Skip detections below the confidence threshold
+            if (detection.confidence <= CONFIDENCE_THRESHOLD)
+                continue;
+
+            // Ensure the object ID is within valid range
+            if (detection.class_id < 0 || static_cast<size_t>(detection.class_id) >= classNames.size())
+                continue;
+
+            // Select color based on object ID for consistent coloring
+            const cv::Scalar& color = colors[detection.class_id % colors.size()];
+
+            // Draw the bounding box rectangle
+            cv::rectangle(image, cv::Point(detection.x1, detection.y1), cv::Point(detection.x2, detection.y2), color, 2, cv::LINE_AA);
+
+            // Prepare label text with class name and confidence percentage
+            const std::string& label = classNames[detection.class_id];
+            std::string confidenceText = std::to_string(static_cast<int>(detection.confidence * 100)) + "%";
+
+            // Define text properties for labels
+            int fontFace = cv::FONT_HERSHEY_SIMPLEX;
+            double fontScale = 0.5;
+            int thickness = 1;
+            int baseline = 0;
+
+            // Calculate text size for background rectangles
+            cv::Size textSize = cv::getTextSize(label, fontFace, fontScale, thickness, &baseline);
+            cv::Size confidenceSize = cv::getTextSize(confidenceText, fontFace, fontScale, thickness, &baseline);
+
+            // Define positions for the label and confidence text
+            cv::Point textOrg(detection.x1, detection.y1 - 10);
+            cv::Point confidenceOrg(detection.x1, detection.y2 + confidenceSize.height + 10);
+
+            // Ensure text does not go out of image boundaries
+            textOrg.y = std::max(textOrg.y, textSize.height);
+            confidenceOrg.y = std::min(confidenceOrg.y, image.rows - 1);
+
+            // Draw background rectangles for better text visibility
+            cv::rectangle(image, textOrg + cv::Point(0, baseline),
+                        textOrg + cv::Point(textSize.width, -textSize.height),
+                        color, cv::FILLED);
+
+            cv::rectangle(image, confidenceOrg + cv::Point(0, baseline),
+                        confidenceOrg + cv::Point(confidenceSize.width, -confidenceSize.height),
+                        color, cv::FILLED);
+
+            // Render the class label text
+            cv::putText(image, label, textOrg, fontFace, fontScale, cv::Scalar(0, 0, 0), thickness, cv::LINE_AA);
+
+            // Render the confidence percentage text
+            cv::putText(image, confidenceText, confidenceOrg, fontFace, fontScale, cv::Scalar(0, 0, 0), thickness, cv::LINE_AA);
+        }
+    }
+
+    /**
+     * @brief Generates a vector of colors for each class name.
+     * 
+     * @param classNames Vector of class names.
+     * @param seed Seed for random color generation to ensure reproducibility.
+     * @return const std::vector<cv::Scalar>& Reference to the vector of colors.
+     */
+    inline const std::vector<cv::Scalar>& generateColors(const std::vector<std::string>& classNames, int seed = 42) {
+        // Static cache to store colors based on class names to avoid regenerating
+        static std::unordered_map<size_t, std::vector<cv::Scalar>> colorCache;
+
+        // Compute a hash key based on class names to identify unique class configurations
+        size_t hashKey = 0;
+        for (const auto& name : classNames) {
+            hashKey ^= std::hash<std::string>{}(name) + 0x9e3779b9 + (hashKey << 6) + (hashKey >> 2);
+        }
+
+        // Check if colors for this class configuration are already cached
+        auto it = colorCache.find(hashKey);
+        if (it != colorCache.end()) {
+            return it->second;
+        }
+
+        // Generate unique random colors for each class
+        std::vector<cv::Scalar> colors;
+        colors.reserve(classNames.size());
+
+        std::mt19937 rng(seed); // Initialize random number generator with fixed seed
+        std::uniform_int_distribution<int> uni(0, 255); // Define distribution for color values
+
+        for (size_t i = 0; i < classNames.size(); ++i) {
+            colors.emplace_back(cv::Scalar(uni(rng), uni(rng), uni(rng))); // Generate random BGR color
+        }
+
+        // Cache the generated colors for future use
+        colorCache.emplace(hashKey, colors);
+
+        return colorCache[hashKey];
+    }
+
+    inline void drawBoundingBoxMask(cv::Mat &image, const std::vector<Detection> &detections, const std::vector<std::string> &classNames,const std::vector<cv::Scalar>& classColors, float maskAlpha) {
+        // Validate input image
+        if (image.empty()) {
+            std::cerr << "ERROR: Empty image provided to drawBoundingBoxMask." << std::endl;
+            return;
+        }
+
+        const int imgHeight = image.rows;
+        const int imgWidth = image.cols;
+
+        // Precompute dynamic font size and thickness based on image dimensions
+        const double fontSize = std::min(imgHeight, imgWidth) * 0.0006;
+        const int textThickness = std::max(1, static_cast<int>(std::min(imgHeight, imgWidth) * 0.001));
+
+        // Create a mask image for blending (initialized to zero)
+        cv::Mat maskImage(image.size(), image.type(), cv::Scalar::all(0));
+
+        // Precompute necessary data for parallel processing
+        size_t numDetections = detections.size();
+        std::vector<cv::Rect> validBoxes;
+        validBoxes.reserve(numDetections); // Reserve space to avoid reallocations
+
+        // Pre-filter detections to include only those above the confidence threshold and with valid class IDs
+        // This reduces the workload in the parallel section
+        std::vector<const Detection*> filteredDetections;
+        filteredDetections.reserve(numDetections);
+        for (const auto& detection : detections) {
+            if (detection.confidence > CONFIDENCE_THRESHOLD && 
+                detection.class_id >= 0 && 
+                static_cast<size_t>(detection.class_id) < classNames.size()) {
+                filteredDetections.emplace_back(&detection);
+            }
+        }
+
+        size_t validDetections = filteredDetections.size();
+
+        // Parallel region for drawing mask rectangles
+        #pragma omp parallel for schedule(dynamic)
+        for (size_t i = 0; i < validDetections; ++i) {
+            const Detection* detection = filteredDetections[i];
+            int x1 = detection->x1;
+            int y1 = detection->y1;
+            int x2 = detection->x2;
+            int y2 = detection->y2;
+            int classId = detection->class_id;
+
+            // Calculate width and height from coordinates
+            int width = x2 - x1;
+            int height = y2 - y1;
+
+            // Define the bounding box as a cv::Rect
+            cv::Rect box(x1, y1, width, height);
+
+            // Retrieve the color associated with the detected class
+            const cv::Scalar &color = classColors[classId];
+
+            // Draw filled rectangle on the mask image for the semi-transparent overlay
+            cv::rectangle(maskImage, box, color, cv::FILLED);
+        }
+
+        // Blend the maskImage with the original image to apply the semi-transparent masks
+        cv::addWeighted(maskImage, maskAlpha, image, 1.0, 0, image);
+
+        // Parallel region for drawing bounding boxes and labels
+        #pragma omp parallel for schedule(dynamic)
+        for (size_t i = 0; i < validDetections; ++i) {
+            const Detection* detection = filteredDetections[i];
+            int x1 = detection->x1;
+            int y1 = detection->y1;
+            int x2 = detection->x2;
+            int y2 = detection->y2;
+            int classId = detection->class_id;
+
+            // Calculate width and height from coordinates
+            int width = x2 - x1;
+            int height = y2 - y1;
+
+            // Define the bounding box as a cv::Rect
+            cv::Rect box(x1, y1, width, height);
+
+            // Retrieve the color associated with the detected class
+            const cv::Scalar &color = classColors[classId];
+
+            // Draw the bounding box on the original image with anti-aliased lines for smoothness
+            cv::rectangle(image, box, color, 2, cv::LINE_AA);
+
+            // Prepare the label with class name and confidence percentage
+            // Preallocate a buffer for the label string to avoid dynamic memory allocation
+            char labelBuffer[256];
+            std::snprintf(labelBuffer, sizeof(labelBuffer), "%s: %.0f%%", classNames[classId].c_str(), detection->confidence * 100.0f);
+            std::string label(labelBuffer);
+
+            // Determine the baseline for text placement
+            int baseLine = 0;
+
+            // Calculate the size of the label text for background rectangle
+            cv::Size labelSize = cv::getTextSize(label, cv::FONT_HERSHEY_SIMPLEX, fontSize, textThickness, &baseLine);
+
+            // Ensure the label does not go above the image
+            int labelY = std::max(y1, labelSize.height + 5);
+
+            // Define the top-left and bottom-right points for the label background rectangle
+            cv::Point labelTopLeft(x1, labelY - labelSize.height - 5);
+            cv::Point labelBottomRight(x1 + labelSize.width + 5, labelY + baseLine - 5);
+
+            // Draw the background rectangle for the label for better visibility
+            cv::rectangle(image, labelTopLeft, labelBottomRight, color, cv::FILLED);
+
+            // Put the label text within the background rectangle
+            cv::putText(image, label, cv::Point(x1 + 2, labelY - 2), cv::FONT_HERSHEY_SIMPLEX, fontSize, cv::Scalar(255, 255, 255), textThickness, cv::LINE_AA);
+        }
+
+        DEBUG_PRINT("Bounding boxes and masks drawn on image.");
+    }
+
+}
+
+// YOLO9Detector class handles loading the YOLO model, preprocessing images, running inference, and postprocessing results
+class YOLO9Detector {
+public:
+    /**
+     * @brief Constructor to initialize the YOLO detector with model and label paths.
+     * 
+     * @param modelPath Path to the ONNX model file.
+     * @param labelsPath Path to the file containing class labels.
+     * @param useGPU Whether to use GPU for inference (default is false).
+     */
+    YOLO9Detector(const std::string &modelPath, const std::string &labelsPath, bool useGPU = false);
+
+    /**
+     * @brief Runs detection on the provided image.
+     * 
+     * @param image Input image for detection.
+     * @return std::vector<Detection> Vector of detections.
+     */
+    std::vector<Detection> detect(const cv::Mat &image);
+
+    /**
+     * @brief Draws bounding boxes on the image based on detections.
+     * 
+     * @param image Image on which to draw.
+     * @param detectionVector Vector of detections.
+     */
+    void drawBoundingBox(cv::Mat &image, std::vector<Detection> &detectionVector) {
+        utils::drawBoundingBox(image, detectionVector, classNames, classColors);
+    }
+
+    void drawBoundingBoxMask(cv::Mat &image, const std::vector<Detection> &detections, float maskAlpha = 0.4)
+    {
+        utils::drawBoundingBoxMask(image, detections, classNames, classColors, maskAlpha);
+    }
+
+
+private:
+    Ort::Env env{nullptr};                     // ONNX Runtime environment
+    Ort::SessionOptions sessionOptions{nullptr}; // Session options for ONNX Runtime
+    Ort::Session session{nullptr};             // ONNX Runtime session for running inference
+    bool isDynamicInputShape{};                // Flag indicating if input shape is dynamic
+    cv::Size inputImageShape;                  // Expected input image shape for the model
+
+    // Vectors to hold allocated input and output node names
+    std::vector<Ort::AllocatedStringPtr> inputNodeNameAllocatedStrings;
+    std::vector<const char *> inputNames;
+    std::vector<Ort::AllocatedStringPtr> outputNodeNameAllocatedStrings;
+    std::vector<const char *> outputNames;
+
+    size_t numInputNodes, numOutputNodes;      // Number of input and output nodes in the model
+
+    /**
+     * @brief Preprocesses the input image for model inference.
+     * 
+     * @param image Input image.
+     * @param blob Reference to pointer where preprocessed data will be stored.
+     * @param inputTensorShape Reference to vector representing input tensor shape.
+     * @return cv::Mat Resized and padded image.
+     */
+    cv::Mat preprocess(const cv::Mat &image, float *&blob, std::vector<int64_t> &inputTensorShape);
+
+
+    /**
+     * @brief Postprocesses the model output to extract detections.
+     * 
+     * @param originalImageSize Size of the original input image.
+     * @param resizedImageShape Size of the image after preprocessing.
+     * @param outputTensors Vector of output tensors from the model.
+     * @return std::vector<Detection> Vector of detections.
+     */
+    std::vector<Detection> postprocess(const cv::Size &originalImageSize, const cv::Size &resizedImageShape, std::vector<Ort::Value> &outputTensors);
+
+    std::vector<std::string> classNames;        // Vector of class names loaded from file
+    std::vector<cv::Scalar> classColors;        // Vector of colors for each class
+};
+
+// Implementation of YOLO9Detector constructor
+YOLO9Detector::YOLO9Detector(const std::string &modelPath, const std::string &labelsPath, bool useGPU) {
+    // Initialize ONNX Runtime environment with warning level
+    env = Ort::Env(ORT_LOGGING_LEVEL_WARNING, "ONNX_DETECTION");
+    sessionOptions = Ort::SessionOptions();
+
+    // Set number of intra-op threads for parallelism
+    sessionOptions.SetIntraOpNumThreads(1);
+    sessionOptions.SetIntraOpNumThreads(std::min(6, (int) std::thread::hardware_concurrency()));
+    sessionOptions.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_ALL);
+
+    // Set the path for the optimized model file (optional)
+    sessionOptions.SetOptimizedModelFilePath(modelPath.c_str());
+
+    // Retrieve available execution providers (e.g., CPU, CUDA)
+    std::vector<std::string> availableProviders = Ort::GetAvailableProviders();
+    auto cudaAvailable = std::find(availableProviders.begin(), availableProviders.end(), "CUDAExecutionProvider");
+    OrtCUDAProviderOptions cudaOption;
+
+    // Configure session options based on whether GPU is to be used and available
+    if (useGPU && cudaAvailable == availableProviders.end()) {
+        std::cout << "GPU is not supported by your ONNXRuntime build. Fallback to CPU." << std::endl;
+        std::cout << "Inference device: CPU" << std::endl;
+    } else if (useGPU && cudaAvailable != availableProviders.end()) {
+        std::cout << "Inference device: GPU" << std::endl;
+        sessionOptions.AppendExecutionProvider_CUDA(cudaOption); // Append CUDA execution provider
+    } else {
+        std::cout << "Inference device: CPU" << std::endl;
+    }
+
+    // Load the ONNX model into the session
+#ifdef _WIN32
+    std::wstring w_modelPath(modelPath.begin(), modelPath.end());
+    session = Ort::Session(env, w_modelPath.c_str(), sessionOptions);
+#else
+    session = Ort::Session(env, modelPath.c_str(), sessionOptions);
+#endif
+
+    Ort::AllocatorWithDefaultOptions allocator;
+
+    // Retrieve input tensor shape information
+    Ort::TypeInfo inputTypeInfo = session.GetInputTypeInfo(0);
+    std::vector<int64_t> inputTensorShape = inputTypeInfo.GetTensorTypeAndShapeInfo().GetShape();
+    isDynamicInputShape = inputTensorShape[2] == -1 && inputTensorShape[3] == -1; // Check for dynamic dimensions
+
+    // Allocate and store input node names
+    auto input_name = session.GetInputNameAllocated(0, allocator);
+    inputNodeNameAllocatedStrings.push_back(std::move(input_name));
+    inputNames.push_back(inputNodeNameAllocatedStrings.back().get());
+
+    // Allocate and store output node names
+    auto output_name = session.GetOutputNameAllocated(0, allocator);
+    outputNodeNameAllocatedStrings.push_back(std::move(output_name));
+    outputNames.push_back(outputNodeNameAllocatedStrings.back().get());
+
+
+    // Set the expected input image shape based on the model's input tensor
+    inputImageShape = cv::Size(inputTensorShape[3], inputTensorShape[2]);
+
+    // Get the number of input and output nodes
+    numInputNodes = session.GetInputCount();
+    numOutputNodes = session.GetOutputCount();
+
+    // Load class names and generate corresponding colors
+    classNames = utils::getClassNames(labelsPath);
+    classColors = utils::generateColors(classNames);
+
+    std::cout << "Model loaded successfully with " << numInputNodes << " input nodes and " << numOutputNodes << " output nodes." << std::endl;
+}
+
+// Preprocess function implementation
+cv::Mat YOLO9Detector::preprocess(const cv::Mat &image, float *&blob, std::vector<int64_t> &inputTensorShape) {
+    // Start timing the preprocessing step
+    ScopedTimer timer("Preprocessing");
+
+    cv::Mat resizedImage;
+   
+    // Resize and pad the image using letterBox utility
+    utils::letterBox(image, resizedImage, inputImageShape, cv::Scalar(114, 114, 114), isDynamicInputShape, false, true, 32);
+
+    // Update input tensor shape based on resized image dimensions
+    inputTensorShape[2] = resizedImage.rows;
+    inputTensorShape[3] = resizedImage.cols;
+
+
+    // Convert image to float and normalize to [0, 1]
+    resizedImage.convertTo(resizedImage, CV_32FC3, 1 / 255.0);
+    
+    // Allocate memory for the image blob in CHW format
+    blob = new float[resizedImage.cols * resizedImage.rows * resizedImage.channels()];
+    cv::Size floatImageSize{resizedImage.cols, resizedImage.rows};
+
+    // Split the image into separate channels and store in the blob
+    std::vector<cv::Mat> chw(resizedImage.channels());
+    for (int i = 0; i < resizedImage.channels(); ++i) {
+        chw[i] = cv::Mat(floatImageSize, CV_32FC1, blob + i * floatImageSize.width * floatImageSize.height);
+    }
+    cv::split(resizedImage, chw); // Split channels into the blob
+
+    DEBUG_PRINT("Preprocessing completed");
+
+    return image;
+}
+
+
+std::vector<Detection> YOLO9Detector::postprocess(const cv::Size& originalImageSize, 
+                                                const cv::Size& resizedImageShape,
+                                                std::vector<Ort::Value>& outputTensors) {
+    ScopedTimer timer("Postprocessing");
+    auto* rawOutput = outputTensors[0].GetTensorData<float>();
+    std::vector<int64_t> outputShape = outputTensors[0].GetTensorTypeAndShapeInfo().GetShape();
+    
+    // Expected shape: [1, 84, 8400] where:
+    // - 1: batch size
+    // - 84: 4 box coordinates + 80 class scores
+    // - 8400: number of predictions
+    const int numPredictions = outputShape[2];  // Should be 8400
+    const int numAttributes = outputShape[1];   // Should be 84
+    const int numClasses = numAttributes - 4;   // 80 classes
+
+    std::vector<Detection> detectionVector;
+    detectionVector.reserve(numPredictions);
+
+    for(int i = 0; i < numPredictions; ++i) {
+        // Strided access pattern for [1, 84, 8400] shaped output
+        const float x_center = rawOutput[i + 0 * numPredictions];  // X at stride 0
+        const float y_center = rawOutput[i + 1 * numPredictions];  // Y at stride 1
+        const float width =    rawOutput[i + 2 * numPredictions];  // Width at stride 2
+        const float height =   rawOutput[i + 3 * numPredictions];  // Height at stride 3
+
+        // Find class with maximum score
+        int classId = -1;
+        float maxScore = -FLT_MAX;
+        for(int c = 0; c < numClasses; ++c) {
+            const float score = rawOutput[i + (4 + c) * numPredictions];
+            if(score > maxScore) {
+                maxScore = score;
+                classId = c;
+            }
+        }
+
+        // Filter out low-confidence detections
+        if(maxScore < CONFIDENCE_THRESHOLD) continue;
+
+        // Convert center coordinates to corner coordinates
+        Detection detection(
+            static_cast<int>(x_center - width / 2),  // x1
+            static_cast<int>(y_center - height / 2), // y1
+            static_cast<int>(x_center + width / 2),  // x2
+            static_cast<int>(y_center + height / 2), // y2
+            classId,                                 // class_id
+            maxScore                                 // confidence
+        );
+        
+        // Scale coordinates to original image size (handles letterboxing if needed)
+        utils::scaleResultCoordsToOriginal(resizedImageShape, detection, originalImageSize);
+
+        detectionVector.emplace_back(detection);
+    }
+
+    // Prepare data for NMS
+    std::vector<cv::Rect> boxes;
+    std::vector<float> scores;
+    boxes.reserve(detectionVector.size());
+    scores.reserve(detectionVector.size());
+
+    for(const auto& det : detectionVector) {
+        boxes.emplace_back(cv::Rect(det.x1, det.y1, det.x2 - det.x1, det.y2 - det.y1));
+        scores.push_back(det.confidence);
+    }
+
+    // Apply NMS
+    std::vector<int> indices;
+    cv::dnn::NMSBoxes(boxes, scores, CONFIDENCE_THRESHOLD, NMS_THRESHOLD, indices);
+
+    // Collect final detections
+    std::vector<Detection> finalDetections;
+    finalDetections.reserve(indices.size());
+    for(int idx : indices) {
+        finalDetections.push_back(detectionVector[idx]);
+    }
+
+
+    return finalDetections;
+}
+
+
+// Detect function implementation
+std::vector<Detection> YOLO9Detector::detect(const cv::Mat& image) {
+    // Start timing the overall detection process
+    ScopedTimer timer("Overall detection"); // Commented out for performance
+
+    float* blobPtr = nullptr; // Pointer to hold preprocessed image data
+    
+    // Define the shape of the input tensor (batch size, channels, height, width)
+    std::vector<int64_t> inputTensorShape = {1, 3, inputImageShape.height, inputImageShape.width};
+
+    // Preprocess the image and obtain a pointer to the blob
+    cv::Mat inputImage = preprocess(image, blobPtr, inputTensorShape);
+
+    // Compute the total number of elements in the input tensor
+    size_t inputTensorSize = utils::vectorProduct(inputTensorShape);
+
+    // Create a vector from the blob data for ONNX Runtime input
+    std::vector<float> inputTensorValues(blobPtr, blobPtr + inputTensorSize);
+
+    delete[] blobPtr; // Free the allocated memory for the blob
+
+    // Create an Ort memory info object (can be cached if used repeatedly)
+    static Ort::MemoryInfo memoryInfo = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+
+    // Create input tensor object using the preprocessed data
+    Ort::Value inputTensor = Ort::Value::CreateTensor<float>(
+        memoryInfo,
+        inputTensorValues.data(),
+        inputTensorSize,
+        inputTensorShape.data(),
+        inputTensorShape.size()
+    );
+
+    // Run the inference session with the input tensor and retrieve output tensors
+    std::vector<Ort::Value> outputTensors = session.Run(
+        Ort::RunOptions{nullptr},
+        inputNames.data(),
+        &inputTensor,
+        numInputNodes,
+        outputNames.data(),
+        numOutputNodes
+    );
+
+    // Determine the resized image shape based on input tensor shape
+    cv::Size resizedImageShape(static_cast<int>(inputTensorShape[3]), static_cast<int>(inputTensorShape[2]));
+
+    // Postprocess the output tensors to obtain detections
+    std::vector<Detection> detections = postprocess(image.size(), resizedImageShape, outputTensors);
+
+    return detections; // Return the vector of detections
+}

--- a/models/export_onnx.py
+++ b/models/export_onnx.py
@@ -1,7 +1,7 @@
 from ultralytics import YOLO
 
-# Load the YOLOv11n model
-model = YOLO("yolo11l.pt")
+# Load the YOLOv9s model
+model = YOLO("yolov9s.pt")
 
 # Export the model to ONNX format
-model.export(format="onnx")
+model.export(format = "onnx")

--- a/models/export_onnx.py
+++ b/models/export_onnx.py
@@ -1,7 +1,7 @@
 from ultralytics import YOLO
 
 # Load the YOLOv9s model
-model = YOLO("yolov9s.pt")
+model = YOLO("yolo11n.pt")
 
 # Export the model to ONNX format
 model.export(format = "onnx")

--- a/src/image_inference.cpp
+++ b/src/image_inference.cpp
@@ -1,9 +1,9 @@
 /**
  * @file image_inference.cpp
- * @brief Object detection in a static image using YOLO models (v5, v7, v8, v10).
+ * @brief Object detection in a static image using YOLO models (v5, v7, v8, v9, v10).
  * 
  * This file implements an object detection application that utilizes YOLO 
- * (You Only Look Once) models, specifically versions 5, 7, 8, and 10. 
+ * (You Only Look Once) models, specifically versions 5, 7, 8, 9, and 10. 
  * The application loads a specified image, processes it to detect objects, 
  * and displays the results with bounding boxes around detected objects.
  *
@@ -44,15 +44,16 @@
 // #include "YOLO5.hpp"  // Uncomment for YOLOv5
 // #include "YOLO7.hpp"  // Uncomment for YOLOv7
 // #include "YOLO8.hpp"  // Uncomment for YOLOv8
+#include "YOLO9.hpp"  // Uncomment for YOLOv9
 // #include "YOLO10.hpp" // Uncomment for YOLOv10
-#include "YOLO11.hpp" // Uncomment for YOLOv11
+// #include "YOLO11.hpp" // Uncomment for YOLOv11
 
 int main()
 {
 
     // Paths to the model, labels, and test image
     const std::string labelsPath = "../models/coco.names";
-    const std::string imagePath = "../data/dogs.jpg";           // Primary image path
+    const std::string imagePath = "../data/dog.jpg";           // Primary image path
 
     // Uncomment the desired image path for testing
     // const std::string imagePath = "../data/happy_dogs.jpg";  // Alternate image
@@ -63,16 +64,19 @@ int main()
     // const std::string modelPath = "../models/yolo5-n6.onnx";      // YOLOv5
     // const std::string modelPath = "../models/yolo7-tiny.onnx";       // YOLOv7
     // const std::string modelPath = "../models/yolo8n.onnx"; // YOLOv8
-    // const std::string modelPath = "../quantized_models/yolo10n_uint8.onnx"; // Quantized YOLOv10 
-    const std::string modelPath = "../models/yolo11n.onnx"; // YOLOv11 
+    const std::string modelPath = "../models/yolov9s.onnx"; // YOLOv9 
+    // const std::string modelPath = "../models/yolo10n.onnx"; // YOLOv10 
+    // const std::string modelPath = "../quantized_models/yolo10n_uint8.onnx"; // Quantized YOLOv10
+    // const std::string modelPath = "../models/yolo11n.onnx"; // YOLOv11 
 
     // Initialize the YOLO detector with the chosen model and labels
-    bool isGPU = true; // Set to false for CPU processing
+    bool isGPU = false; // Set to false for CPU processing
     // YOLO7Detector detector(modelPath, labelsPath, isGPU);
     // YOLO5Detector detector(modelPath, labelsPath, isGPU);  // Uncomment for YOLOv5
     // YOLO8Detector detector(modelPath, labelsPath, isGPU);  // Uncomment for YOLOv8
+    YOLO9Detector detector(modelPath, labelsPath, isGPU); // Uncomment for YOLOv9
     // YOLO10Detector detector(modelPath, labelsPath, isGPU); // Uncomment for YOLOv10
-    YOLO11Detector detector(modelPath, labelsPath, isGPU); // Uncomment for YOLOv11
+    // YOLO11Detector detector(modelPath, labelsPath, isGPU); // Uncomment for YOLOv11
 
     // Load an image
     cv::Mat image = cv::imread(imagePath);
@@ -81,6 +85,8 @@ int main()
         std::cerr << "Error: Could not open or find the image!\n";
         return -1;
     }
+
+    
 
     // Detect objects in the image and measure execution time
     auto start = std::chrono::high_resolution_clock::now();

--- a/src/image_inference.cpp
+++ b/src/image_inference.cpp
@@ -44,9 +44,9 @@
 // #include "YOLO5.hpp"  // Uncomment for YOLOv5
 // #include "YOLO7.hpp"  // Uncomment for YOLOv7
 // #include "YOLO8.hpp"  // Uncomment for YOLOv8
-#include "YOLO9.hpp"  // Uncomment for YOLOv9
+// #include "YOLO9.hpp"  // Uncomment for YOLOv9
 // #include "YOLO10.hpp" // Uncomment for YOLOv10
-// #include "YOLO11.hpp" // Uncomment for YOLOv11
+#include "YOLO11.hpp" // Uncomment for YOLOv11
 
 int main()
 {
@@ -64,19 +64,19 @@ int main()
     // const std::string modelPath = "../models/yolo5-n6.onnx";      // YOLOv5
     // const std::string modelPath = "../models/yolo7-tiny.onnx";       // YOLOv7
     // const std::string modelPath = "../models/yolo8n.onnx"; // YOLOv8
-    const std::string modelPath = "../models/yolov9s.onnx"; // YOLOv9 
+    // const std::string modelPath = "../models/yolov9s.onnx"; // YOLOv9 
     // const std::string modelPath = "../models/yolo10n.onnx"; // YOLOv10 
     // const std::string modelPath = "../quantized_models/yolo10n_uint8.onnx"; // Quantized YOLOv10
-    // const std::string modelPath = "../models/yolo11n.onnx"; // YOLOv11 
+    const std::string modelPath = "../models/yolo11n.onnx"; // YOLOv11 
 
     // Initialize the YOLO detector with the chosen model and labels
     bool isGPU = false; // Set to false for CPU processing
     // YOLO7Detector detector(modelPath, labelsPath, isGPU);
     // YOLO5Detector detector(modelPath, labelsPath, isGPU);  // Uncomment for YOLOv5
     // YOLO8Detector detector(modelPath, labelsPath, isGPU);  // Uncomment for YOLOv8
-    YOLO9Detector detector(modelPath, labelsPath, isGPU); // Uncomment for YOLOv9
+    // YOLO9Detector detector(modelPath, labelsPath, isGPU); // Uncomment for YOLOv9
     // YOLO10Detector detector(modelPath, labelsPath, isGPU); // Uncomment for YOLOv10
-    // YOLO11Detector detector(modelPath, labelsPath, isGPU); // Uncomment for YOLOv11
+    YOLO11Detector detector(modelPath, labelsPath, isGPU); // Uncomment for YOLOv11
 
     // Load an image
     cv::Mat image = cv::imread(imagePath);

--- a/src/video_inference.cpp
+++ b/src/video_inference.cpp
@@ -1,9 +1,9 @@
 /**
  * @file video_inference.cpp
- * @brief Object detection in a video stream using YOLO models (v5, v7, v8, v10).
+ * @brief Object detection in a video stream using YOLO models (v5, v7, v8, v9, v10).
  * 
  * This file implements an object detection application that utilizes YOLO 
- * (You Only Look Once) models, specifically versions 5, 7, 8, and 10. 
+ * (You Only Look Once) models, specifically versions 5, 7, 8, 9, and 10. 
  * The application processes a video stream to detect objects and saves 
  * the results to a new video file with bounding boxes around detected objects.
  *
@@ -50,8 +50,9 @@
 // #include "YOLO5.hpp"  // Uncomment for YOLOv5
 // #include "YOLO7.hpp"  // Uncomment for YOLOv7
 // #include "YOLO8.hpp"  // Uncomment for YOLOv8
+#include "YOLO9.hpp"  // Uncomment for YOLOv9
 // #include "YOLO10.hpp" // Uncomment for YOLOv10
-#include "YOLO11.hpp" // Uncomment for YOLOv10
+// #include "YOLO11.hpp" // Uncomment for YOLOv10
 
 // Thread-safe queue implementation
 template <typename T>
@@ -99,11 +100,13 @@ int main()
     const std::string outputPath = "../data/SIG_experience_center_processed.mp4"; // Output video path
 
     // Model paths for different YOLO versions
-    const std::string modelPath = "../models/yolo11n.onnx"; // YOLOv11
+    const std::string modelPath = "../models/yolov9s.onnx"; // YOLOv9
+    // const std::string modelPath = "../models/yolo11n.onnx"; // YOLOv11
 
     // Initialize the YOLO detector
-    bool isGPU = true; // Set to false for CPU processing
-    YOLO11Detector detector(modelPath, labelsPath, isGPU); // YOLOv11
+    bool isGPU = false; // Set to false for CPU processing
+    YOLO9Detector detector(modelPath, labelsPath, isGPU); // YOLOv9
+    // YOLO11Detector detector(modelPath, labelsPath, isGPU); // YOLOv11
 
     // Open the video file
     cv::VideoCapture cap(videoPath);


### PR DESCRIPTION
I was testing YOLO11 for object detection and obtained the following output:

![1](https://github.com/user-attachments/assets/a7de9747-53a5-4748-8fe0-58f4c5696501)


Initially, I assumed that ONNX models are compatible only with the device they were generated on, which turned out to be correct. To verify this, I used export.py to export my own YOLOv11 ONNX model. After doing so, I obtained the following output:

![2](https://github.com/user-attachments/assets/29de8936-8c52-4781-b0a7-4a5806c5f34e)


However, the lack of output made me question where the issue might lie. I immediately suspected the post-processing step, and I was right. The following part of the code was incorrect:

![3](https://github.com/user-attachments/assets/6de1fe0b-de7c-4b79-8688-9dcc2506ed37)

After fixing the issue, the output was successfully corrected:

![4](https://github.com/user-attachments/assets/fc059ca7-4439-4a04-8ed8-e5989438e37c)

![5](https://github.com/user-attachments/assets/3a6d77db-efe1-4819-8c7a-12c8066a2319)

