### PR TITLE
Yolov9 Segmentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
 
 #### 📌 Pinned
 
+* [2025.01.31] 🎯🎯🎯 YOLOs-CPP now supports YOLOv9 for Segmentation. Thanks to [Mohamed Samir](https://github.com/mohamedsamirx).
+
 * [2025.01.29] 🎯🎯🎯 YOLOs-CPP now supports YOLOv9 for object detection. Thanks to [Mohamed Samir](https://github.com/mohamedsamirx).
 
 * [2025.01.26] 🔥🔥🔥  YOLOS-CPP Provide now segmentation headers for YOLOv8 and YOLOv11 also quantized models.
@@ -110,7 +112,7 @@ int main()
     cv::Mat image = cv::imread(imagePath);
 
     // Perform object segmentation to get segmentation masks and bboxs
-    std::vector<Segmentation> results = detector.segment(img, 0.2f, 0.45f);
+    std::vector<Segmentation> results = segmentor.segment(image, 0.2f, 0.45f);
 
     // Draw bounding boxes on the image
     segmentor.drawSegmentations(image, results);          // Masks only
@@ -248,6 +250,7 @@ The project includes various pertained standard YOLO models stored in the `model
 |                  | yolo8n.onnx                |
 |                  | yolo8n-seg.onnx                |
 |                  | yolov9s.onnx               |
+|                  | yolov9c-seg.onnx           |
 |                  | yolo10n.onnx               |
 |                  | yolo11n.onnx               |
 |                  | yolo11n-seg.onnx               |

--- a/README.md
+++ b/README.md
@@ -12,12 +12,14 @@
 
 ## Overview
 
-**YOLOs-CPP** provides single c++ headers with high-performance application designed for real-time object detection and segmentation using various YOLO (You Only Look Once) models from [Ultralytics](https://github.com/ultralytics/ultralytics). Leveraging the power of [ONNX Runtime](https://github.com/microsoft/onnxruntime) and [OpenCV](https://opencv.org/), this project provides seamless integration with unified YOLOv(5,7,8,10,11) implementation for image, video, and live camera inference. Whether you're developing for research, production, or hobbyist projects, this application offers flexibility and efficiency.
+**YOLOs-CPP** provides single c++ headers with high-performance application designed for real-time object detection and segmentation using various YOLO (You Only Look Once) models from [Ultralytics](https://github.com/ultralytics/ultralytics). Leveraging the power of [ONNX Runtime](https://github.com/microsoft/onnxruntime) and [OpenCV](https://opencv.org/), this project provides seamless integration with unified YOLOv(5,7,8,9,10,11) implementation for image, video, and live camera inference. Whether you're developing for research, production, or hobbyist projects, this application offers flexibility and efficiency.
 
 
 ## News 
 
 #### 📌 Pinned
+
+* [2025.01.29] 🎯🎯🎯 YOLOs-CPP now supports YOLOv9 for object detection. Thanks to [Mohamed Samir](https://github.com/mohamedsamirx).
 
 * [2025.01.26] 🔥🔥🔥  YOLOS-CPP Provide now segmentation headers for YOLOv8 and YOLOv11 also quantized models.
 
@@ -128,7 +130,7 @@ int main()
 ## Features
 
 
-- **Multiple YOLO Models**: Supports YOLOv5, YOLOv7, YOLOv8, YOLOv10, and YOLOv11 with standard and quantized ONNX models for flexibility in use cases.
+- **Multiple YOLO Models**: Supports YOLOv5, YOLOv7, YOLOv8, YOLOv9, YOLOv10, and YOLOv11 with standard and quantized ONNX models for flexibility in use cases.
   
 - **ONNX Runtime Integration**: Leverages ONNX Runtime for optimized inference on both CPU and GPU, ensuring high performance.
   - **Dynamic Shapes Handling**: Adapts automatically to varying input sizes for improved versatility.
@@ -222,11 +224,6 @@ To perform object detection on a video file:
 ./run_video.sh 
 ```
 
-**Example:**
-```bash
-./run_video.sh 
-```
-
 The above command will process [SIG_experience_center.mp4](data/SIG_experience_center.mp4) using the YOLO11n model and save the output video with detected objects.
 
 #### Run Camera Inference
@@ -250,6 +247,7 @@ The project includes various pertained standard YOLO models stored in the `model
 |                  | yolo7-tiny.onnx            |
 |                  | yolo8n.onnx                |
 |                  | yolo8n-seg.onnx                |
+|                  | yolov9s.onnx               |
 |                  | yolo10n.onnx               |
 |                  | yolo11n.onnx               |
 |                  | yolo11n-seg.onnx               |

--- a/include/YOLO9.hpp
+++ b/include/YOLO9.hpp
@@ -1,0 +1,759 @@
+#pragma once
+
+// ===================================
+// Single YOLOv9 Detector Header File
+// ===================================
+//
+// This header defines the YOLO9Detector class for performing object detection using the YOLOv9 model.
+// It includes necessary libraries, utility structures, and helper functions to facilitate model inference
+// and result postprocessing.
+//
+// Author: Mohamed Samir, https://www.linkedin.com/in/mohamed-samir-7a730b237/
+// Date: 29.01.2025
+//
+// ================================
+
+/**
+ * @file YOLO9Detector.hpp
+ * @brief Header file for the YOLO9Detector class, responsible for object detection
+ *        using the YOLOv9 model with optimized performance for minimal latency.
+ */
+
+
+// Include necessary ONNX Runtime and OpenCV headers
+#include <onnxruntime_cxx_api.h>
+#include <opencv2/opencv.hpp>
+
+// Include standard libraries for various utilities
+#include <vector>
+#include <string>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <chrono>
+#include <random>
+#include <memory>
+#include <thread>
+
+
+// Include debug and custom ScopedTimer tools for performance measurement
+#include "tools/Debug.hpp"
+#include "tools/ScopedTimer.hpp"
+
+/**
+ * @brief Confidence threshold for filtering detections.
+ */
+const float CONFIDENCE_THRESHOLD = 0.45f;
+
+/**
+ * @brief Confidence threshold for filtering detections.
+ */
+const float NMS_THRESHOLD = 0.4f;
+
+
+
+/**
+ * @brief Struct to represent a single detection with bounding box.
+ */
+struct Detection {
+    int x1, y1, x2, y2;   // Coordinates of the bounding box
+    int class_id;         // Object class ID
+    float confidence;     // Confidence score of the detection
+
+    // Constructor to initialize all members
+    Detection(int x1, int y1, int x2, int y2, int class_id, float confidence)
+        : x1(x1), y1(y1), x2(x2), y2(y2), class_id(class_id), confidence(confidence) {}
+};
+
+/**
+ * @namespace utils
+ * @brief Namespace containing utility functions for the YOLO9Detector.
+ */
+namespace utils {
+    /**
+     * @brief Loads class names from a given file path.
+     * 
+     * @param path Path to the file containing class names.
+     * @return std::vector<std::string> Vector of class names.
+     */
+    std::vector<std::string> getClassNames(const std::string &path) {
+        std::vector<std::string> classNames;
+        std::ifstream infile(path);
+
+        if (infile) {
+            std::string line;
+            while (getline(infile, line)) {
+                // Remove carriage return if present (for Windows compatibility)
+                if (!line.empty() && line.back() == '\r')
+                    line.pop_back();
+                classNames.emplace_back(line);
+            }
+        } else {
+            std::cerr << "ERROR: Failed to access class name path: " << path << std::endl;
+        }
+
+        DEBUG_PRINT("Loaded class names from " + path);
+        return classNames;
+    }
+
+    /**
+     * @brief Computes the product of elements in a vector.
+     * 
+     * @param vector Vector of integers.
+     * @return size_t Product of all elements.
+     */
+    size_t vectorProduct(const std::vector<int64_t> &vector) {
+        return std::accumulate(vector.begin(), vector.end(), 1ull, std::multiplies<size_t>());
+    }
+    
+    /**
+     * @brief Resizes an image with letterboxing to maintain aspect ratio.
+     * 
+     * @param image Input image.
+     * @param outImage Output resized and padded image.
+     * @param newShape Desired output size.
+     * @param color Padding color (default is gray).
+     * @param auto_ Automatically adjust padding to be multiple of stride.
+     * @param scaleFill Whether to scale to fill the new shape without keeping aspect ratio.
+     * @param scaleUp Whether to allow scaling up of the image.
+     * @param stride Stride size for padding alignment.
+     */
+    inline void letterBox(const cv::Mat& image, cv::Mat& outImage,
+                        const cv::Size& newShape,
+                        const cv::Scalar& color = cv::Scalar(114, 114, 114),
+                        bool auto_ = true,
+                        bool scaleFill = false,
+                        bool scaleUp = true,
+                        int stride = 32) {
+        // Calculate the scaling ratio to fit the image within the new shape
+        float ratio = std::min(static_cast<float>(newShape.height) / image.rows,
+                            static_cast<float>(newShape.width) / image.cols);
+
+        // Prevent scaling up if not allowed
+        if (!scaleUp) {
+            ratio = std::min(ratio, 1.0f);
+        }
+
+        // Calculate new dimensions after scaling
+        int newUnpadW = static_cast<int>(std::round(image.cols * ratio));
+        int newUnpadH = static_cast<int>(std::round(image.rows * ratio));
+
+        // Calculate padding needed to reach the desired shape
+        int dw = newShape.width - newUnpadW;
+        int dh = newShape.height - newUnpadH;
+
+        if (auto_) {
+            // Ensure padding is a multiple of stride for model compatibility
+            dw = (dw % stride) / 2;
+            dh = (dh % stride) / 2;
+        } else if (scaleFill) {
+            // Scale to fill without maintaining aspect ratio
+            newUnpadW = newShape.width;
+            newUnpadH = newShape.height;
+            ratio = std::min(static_cast<float>(newShape.width) / image.cols,
+                            static_cast<float>(newShape.height) / image.rows);
+            dw = 0;
+            dh = 0;
+        } else {
+            // Evenly distribute padding on both sides
+            // Calculate separate padding for left/right and top/bottom to handle odd padding
+            int padLeft = dw / 2;
+            int padRight = dw - padLeft;
+            int padTop = dh / 2;
+            int padBottom = dh - padTop;
+
+            // Resize the image if the new dimensions differ
+            if (image.cols != newUnpadW || image.rows != newUnpadH) {
+                cv::resize(image, outImage, cv::Size(newUnpadW, newUnpadH), 0, 0, cv::INTER_LINEAR);
+            } else {
+                // Avoid unnecessary copying if dimensions are the same
+                outImage = image;
+            }
+
+            // Apply padding to reach the desired shape
+            cv::copyMakeBorder(outImage, outImage, padTop, padBottom, padLeft, padRight, cv::BORDER_CONSTANT, color);
+            return; // Exit early since padding is already applied
+        }
+
+        // Resize the image if the new dimensions differ
+        if (image.cols != newUnpadW || image.rows != newUnpadH) {
+            cv::resize(image, outImage, cv::Size(newUnpadW, newUnpadH), 0, 0, cv::INTER_LINEAR);
+        } else {
+            // Avoid unnecessary copying if dimensions are the same
+            outImage = image;
+        }
+
+        // Calculate separate padding for left/right and top/bottom to handle odd padding
+        int padLeft = dw / 2;
+        int padRight = dw - padLeft;
+        int padTop = dh / 2;
+        int padBottom = dh - padTop;
+
+        // Apply padding to reach the desired shape
+        cv::copyMakeBorder(outImage, outImage, padTop, padBottom, padLeft, padRight, cv::BORDER_CONSTANT, color);
+    }
+
+
+    /**
+     * @brief Scales detection coordinates back to the original image size.
+     * 
+     * @param imageShape Shape of the resized image used for inference.
+     * @param bbox Detection bounding box to be scaled.
+     * @param imageOriginalShape Original image size before resizing.
+     */
+    void scaleResultCoordsToOriginal(const cv::Size &imageShape, Detection &bbox, const cv::Size &imageOriginalShape) {
+        // Calculate the scaling factor used during preprocessing
+        float gain = std::min(static_cast<float>(imageShape.width) / static_cast<float>(imageOriginalShape.width),
+                              static_cast<float>(imageShape.height) / static_cast<float>(imageOriginalShape.height));
+
+        // Calculate padding added during preprocessing
+        int padX = static_cast<int>((imageShape.width - imageOriginalShape.width * gain) / 2.0f);
+        int padY = static_cast<int>((imageShape.height - imageOriginalShape.height * gain) / 2.0f);
+
+        // Adjust bounding box coordinates by removing padding and scaling
+        bbox.x1 = static_cast<int>((bbox.x1 - padX) / gain);
+        bbox.y1 = static_cast<int>((bbox.y1 - padY) / gain);
+        bbox.x2 = static_cast<int>((bbox.x2 - padX) / gain);
+        bbox.y2 = static_cast<int>((bbox.y2 - padY) / gain);
+    }
+
+    /**
+     * @brief Draws bounding boxes and labels on the image based on detections.
+     * 
+     * @param image Image on which to draw.
+     * @param detectionVector Vector of detections.
+     * @param classNames Vector of class names corresponding to object IDs.
+     * @param colors Vector of colors for each class.
+     */
+    inline void drawBoundingBox(cv::Mat &image, std::vector<Detection> &detectionVector, const std::vector<std::string> &classNames, const std::vector<cv::Scalar>& colors) {
+        // Precompute the number of detections to iterate efficiently
+        size_t numDetections = detectionVector.size();
+
+        // Iterate through each detection to draw bounding boxes and labels
+        for (size_t i = 0; i < numDetections; ++i) {
+            const auto& detection = detectionVector[i];
+
+            // Skip detections below the confidence threshold
+            if (detection.confidence <= CONFIDENCE_THRESHOLD)
+                continue;
+
+            // Ensure the object ID is within valid range
+            if (detection.class_id < 0 || static_cast<size_t>(detection.class_id) >= classNames.size())
+                continue;
+
+            // Select color based on object ID for consistent coloring
+            const cv::Scalar& color = colors[detection.class_id % colors.size()];
+
+            // Draw the bounding box rectangle
+            cv::rectangle(image, cv::Point(detection.x1, detection.y1), cv::Point(detection.x2, detection.y2), color, 2, cv::LINE_AA);
+
+            // Prepare label text with class name and confidence percentage
+            const std::string& label = classNames[detection.class_id];
+            std::string confidenceText = std::to_string(static_cast<int>(detection.confidence * 100)) + "%";
+
+            // Define text properties for labels
+            int fontFace = cv::FONT_HERSHEY_SIMPLEX;
+            double fontScale = 0.5;
+            int thickness = 1;
+            int baseline = 0;
+
+            // Calculate text size for background rectangles
+            cv::Size textSize = cv::getTextSize(label, fontFace, fontScale, thickness, &baseline);
+            cv::Size confidenceSize = cv::getTextSize(confidenceText, fontFace, fontScale, thickness, &baseline);
+
+            // Define positions for the label and confidence text
+            cv::Point textOrg(detection.x1, detection.y1 - 10);
+            cv::Point confidenceOrg(detection.x1, detection.y2 + confidenceSize.height + 10);
+
+            // Ensure text does not go out of image boundaries
+            textOrg.y = std::max(textOrg.y, textSize.height);
+            confidenceOrg.y = std::min(confidenceOrg.y, image.rows - 1);
+
+            // Draw background rectangles for better text visibility
+            cv::rectangle(image, textOrg + cv::Point(0, baseline),
+                        textOrg + cv::Point(textSize.width, -textSize.height),
+                        color, cv::FILLED);
+
+            cv::rectangle(image, confidenceOrg + cv::Point(0, baseline),
+                        confidenceOrg + cv::Point(confidenceSize.width, -confidenceSize.height),
+                        color, cv::FILLED);
+
+            // Render the class label text
+            cv::putText(image, label, textOrg, fontFace, fontScale, cv::Scalar(0, 0, 0), thickness, cv::LINE_AA);
+
+            // Render the confidence percentage text
+            cv::putText(image, confidenceText, confidenceOrg, fontFace, fontScale, cv::Scalar(0, 0, 0), thickness, cv::LINE_AA);
+        }
+    }
+
+    /**
+     * @brief Generates a vector of colors for each class name.
+     * 
+     * @param classNames Vector of class names.
+     * @param seed Seed for random color generation to ensure reproducibility.
+     * @return const std::vector<cv::Scalar>& Reference to the vector of colors.
+     */
+    inline const std::vector<cv::Scalar>& generateColors(const std::vector<std::string>& classNames, int seed = 42) {
+        // Static cache to store colors based on class names to avoid regenerating
+        static std::unordered_map<size_t, std::vector<cv::Scalar>> colorCache;
+
+        // Compute a hash key based on class names to identify unique class configurations
+        size_t hashKey = 0;
+        for (const auto& name : classNames) {
+            hashKey ^= std::hash<std::string>{}(name) + 0x9e3779b9 + (hashKey << 6) + (hashKey >> 2);
+        }
+
+        // Check if colors for this class configuration are already cached
+        auto it = colorCache.find(hashKey);
+        if (it != colorCache.end()) {
+            return it->second;
+        }
+
+        // Generate unique random colors for each class
+        std::vector<cv::Scalar> colors;
+        colors.reserve(classNames.size());
+
+        std::mt19937 rng(seed); // Initialize random number generator with fixed seed
+        std::uniform_int_distribution<int> uni(0, 255); // Define distribution for color values
+
+        for (size_t i = 0; i < classNames.size(); ++i) {
+            colors.emplace_back(cv::Scalar(uni(rng), uni(rng), uni(rng))); // Generate random BGR color
+        }
+
+        // Cache the generated colors for future use
+        colorCache.emplace(hashKey, colors);
+
+        return colorCache[hashKey];
+    }
+
+    inline void drawBoundingBoxMask(cv::Mat &image, const std::vector<Detection> &detections, const std::vector<std::string> &classNames,const std::vector<cv::Scalar>& classColors, float maskAlpha) {
+        // Validate input image
+        if (image.empty()) {
+            std::cerr << "ERROR: Empty image provided to drawBoundingBoxMask." << std::endl;
+            return;
+        }
+
+        const int imgHeight = image.rows;
+        const int imgWidth = image.cols;
+
+        // Precompute dynamic font size and thickness based on image dimensions
+        const double fontSize = std::min(imgHeight, imgWidth) * 0.0006;
+        const int textThickness = std::max(1, static_cast<int>(std::min(imgHeight, imgWidth) * 0.001));
+
+        // Create a mask image for blending (initialized to zero)
+        cv::Mat maskImage(image.size(), image.type(), cv::Scalar::all(0));
+
+        // Precompute necessary data for parallel processing
+        size_t numDetections = detections.size();
+        std::vector<cv::Rect> validBoxes;
+        validBoxes.reserve(numDetections); // Reserve space to avoid reallocations
+
+        // Pre-filter detections to include only those above the confidence threshold and with valid class IDs
+        // This reduces the workload in the parallel section
+        std::vector<const Detection*> filteredDetections;
+        filteredDetections.reserve(numDetections);
+        for (const auto& detection : detections) {
+            if (detection.confidence > CONFIDENCE_THRESHOLD && 
+                detection.class_id >= 0 && 
+                static_cast<size_t>(detection.class_id) < classNames.size()) {
+                filteredDetections.emplace_back(&detection);
+            }
+        }
+
+        size_t validDetections = filteredDetections.size();
+
+        // Parallel region for drawing mask rectangles
+        #pragma omp parallel for schedule(dynamic)
+        for (size_t i = 0; i < validDetections; ++i) {
+            const Detection* detection = filteredDetections[i];
+            int x1 = detection->x1;
+            int y1 = detection->y1;
+            int x2 = detection->x2;
+            int y2 = detection->y2;
+            int classId = detection->class_id;
+
+            // Calculate width and height from coordinates
+            int width = x2 - x1;
+            int height = y2 - y1;
+
+            // Define the bounding box as a cv::Rect
+            cv::Rect box(x1, y1, width, height);
+
+            // Retrieve the color associated with the detected class
+            const cv::Scalar &color = classColors[classId];
+
+            // Draw filled rectangle on the mask image for the semi-transparent overlay
+            cv::rectangle(maskImage, box, color, cv::FILLED);
+        }
+
+        // Blend the maskImage with the original image to apply the semi-transparent masks
+        cv::addWeighted(maskImage, maskAlpha, image, 1.0, 0, image);
+
+        // Parallel region for drawing bounding boxes and labels
+        #pragma omp parallel for schedule(dynamic)
+        for (size_t i = 0; i < validDetections; ++i) {
+            const Detection* detection = filteredDetections[i];
+            int x1 = detection->x1;
+            int y1 = detection->y1;
+            int x2 = detection->x2;
+            int y2 = detection->y2;
+            int classId = detection->class_id;
+
+            // Calculate width and height from coordinates
+            int width = x2 - x1;
+            int height = y2 - y1;
+
+            // Define the bounding box as a cv::Rect
+            cv::Rect box(x1, y1, width, height);
+
+            // Retrieve the color associated with the detected class
+            const cv::Scalar &color = classColors[classId];
+
+            // Draw the bounding box on the original image with anti-aliased lines for smoothness
+            cv::rectangle(image, box, color, 2, cv::LINE_AA);
+
+            // Prepare the label with class name and confidence percentage
+            // Preallocate a buffer for the label string to avoid dynamic memory allocation
+            char labelBuffer[256];
+            std::snprintf(labelBuffer, sizeof(labelBuffer), "%s: %.0f%%", classNames[classId].c_str(), detection->confidence * 100.0f);
+            std::string label(labelBuffer);
+
+            // Determine the baseline for text placement
+            int baseLine = 0;
+
+            // Calculate the size of the label text for background rectangle
+            cv::Size labelSize = cv::getTextSize(label, cv::FONT_HERSHEY_SIMPLEX, fontSize, textThickness, &baseLine);
+
+            // Ensure the label does not go above the image
+            int labelY = std::max(y1, labelSize.height + 5);
+
+            // Define the top-left and bottom-right points for the label background rectangle
+            cv::Point labelTopLeft(x1, labelY - labelSize.height - 5);
+            cv::Point labelBottomRight(x1 + labelSize.width + 5, labelY + baseLine - 5);
+
+            // Draw the background rectangle for the label for better visibility
+            cv::rectangle(image, labelTopLeft, labelBottomRight, color, cv::FILLED);
+
+            // Put the label text within the background rectangle
+            cv::putText(image, label, cv::Point(x1 + 2, labelY - 2), cv::FONT_HERSHEY_SIMPLEX, fontSize, cv::Scalar(255, 255, 255), textThickness, cv::LINE_AA);
+        }
+
+        DEBUG_PRINT("Bounding boxes and masks drawn on image.");
+    }
+
+}
+
+// YOLO9Detector class handles loading the YOLO model, preprocessing images, running inference, and postprocessing results
+class YOLO9Detector {
+public:
+    /**
+     * @brief Constructor to initialize the YOLO detector with model and label paths.
+     * 
+     * @param modelPath Path to the ONNX model file.
+     * @param labelsPath Path to the file containing class labels.
+     * @param useGPU Whether to use GPU for inference (default is false).
+     */
+    YOLO9Detector(const std::string &modelPath, const std::string &labelsPath, bool useGPU = false);
+
+    /**
+     * @brief Runs detection on the provided image.
+     * 
+     * @param image Input image for detection.
+     * @return std::vector<Detection> Vector of detections.
+     */
+    std::vector<Detection> detect(const cv::Mat &image);
+
+    /**
+     * @brief Draws bounding boxes on the image based on detections.
+     * 
+     * @param image Image on which to draw.
+     * @param detectionVector Vector of detections.
+     */
+    void drawBoundingBox(cv::Mat &image, std::vector<Detection> &detectionVector) {
+        utils::drawBoundingBox(image, detectionVector, classNames, classColors);
+    }
+
+    void drawBoundingBoxMask(cv::Mat &image, const std::vector<Detection> &detections, float maskAlpha = 0.4)
+    {
+        utils::drawBoundingBoxMask(image, detections, classNames, classColors, maskAlpha);
+    }
+
+
+private:
+    Ort::Env env{nullptr};                     // ONNX Runtime environment
+    Ort::SessionOptions sessionOptions{nullptr}; // Session options for ONNX Runtime
+    Ort::Session session{nullptr};             // ONNX Runtime session for running inference
+    bool isDynamicInputShape{};                // Flag indicating if input shape is dynamic
+    cv::Size inputImageShape;                  // Expected input image shape for the model
+
+    // Vectors to hold allocated input and output node names
+    std::vector<Ort::AllocatedStringPtr> inputNodeNameAllocatedStrings;
+    std::vector<const char *> inputNames;
+    std::vector<Ort::AllocatedStringPtr> outputNodeNameAllocatedStrings;
+    std::vector<const char *> outputNames;
+
+    size_t numInputNodes, numOutputNodes;      // Number of input and output nodes in the model
+
+    /**
+     * @brief Preprocesses the input image for model inference.
+     * 
+     * @param image Input image.
+     * @param blob Reference to pointer where preprocessed data will be stored.
+     * @param inputTensorShape Reference to vector representing input tensor shape.
+     * @return cv::Mat Resized and padded image.
+     */
+    cv::Mat preprocess(const cv::Mat &image, float *&blob, std::vector<int64_t> &inputTensorShape);
+
+
+    /**
+     * @brief Postprocesses the model output to extract detections.
+     * 
+     * @param originalImageSize Size of the original input image.
+     * @param resizedImageShape Size of the image after preprocessing.
+     * @param outputTensors Vector of output tensors from the model.
+     * @return std::vector<Detection> Vector of detections.
+     */
+    std::vector<Detection> postprocess(const cv::Size &originalImageSize, const cv::Size &resizedImageShape, std::vector<Ort::Value> &outputTensors);
+
+    std::vector<std::string> classNames;        // Vector of class names loaded from file
+    std::vector<cv::Scalar> classColors;        // Vector of colors for each class
+};
+
+// Implementation of YOLO9Detector constructor
+YOLO9Detector::YOLO9Detector(const std::string &modelPath, const std::string &labelsPath, bool useGPU) {
+    // Initialize ONNX Runtime environment with warning level
+    env = Ort::Env(ORT_LOGGING_LEVEL_WARNING, "ONNX_DETECTION");
+    sessionOptions = Ort::SessionOptions();
+
+    // Set number of intra-op threads for parallelism
+    sessionOptions.SetIntraOpNumThreads(1);
+    sessionOptions.SetIntraOpNumThreads(std::min(6, (int) std::thread::hardware_concurrency()));
+    sessionOptions.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_ALL);
+
+    // Set the path for the optimized model file (optional)
+    sessionOptions.SetOptimizedModelFilePath(modelPath.c_str());
+
+    // Retrieve available execution providers (e.g., CPU, CUDA)
+    std::vector<std::string> availableProviders = Ort::GetAvailableProviders();
+    auto cudaAvailable = std::find(availableProviders.begin(), availableProviders.end(), "CUDAExecutionProvider");
+    OrtCUDAProviderOptions cudaOption;
+
+    // Configure session options based on whether GPU is to be used and available
+    if (useGPU && cudaAvailable == availableProviders.end()) {
+        std::cout << "GPU is not supported by your ONNXRuntime build. Fallback to CPU." << std::endl;
+        std::cout << "Inference device: CPU" << std::endl;
+    } else if (useGPU && cudaAvailable != availableProviders.end()) {
+        std::cout << "Inference device: GPU" << std::endl;
+        sessionOptions.AppendExecutionProvider_CUDA(cudaOption); // Append CUDA execution provider
+    } else {
+        std::cout << "Inference device: CPU" << std::endl;
+    }
+
+    // Load the ONNX model into the session
+#ifdef _WIN32
+    std::wstring w_modelPath(modelPath.begin(), modelPath.end());
+    session = Ort::Session(env, w_modelPath.c_str(), sessionOptions);
+#else
+    session = Ort::Session(env, modelPath.c_str(), sessionOptions);
+#endif
+
+    Ort::AllocatorWithDefaultOptions allocator;
+
+    // Retrieve input tensor shape information
+    Ort::TypeInfo inputTypeInfo = session.GetInputTypeInfo(0);
+    std::vector<int64_t> inputTensorShape = inputTypeInfo.GetTensorTypeAndShapeInfo().GetShape();
+    isDynamicInputShape = inputTensorShape[2] == -1 && inputTensorShape[3] == -1; // Check for dynamic dimensions
+
+    // Allocate and store input node names
+    auto input_name = session.GetInputNameAllocated(0, allocator);
+    inputNodeNameAllocatedStrings.push_back(std::move(input_name));
+    inputNames.push_back(inputNodeNameAllocatedStrings.back().get());
+
+    // Allocate and store output node names
+    auto output_name = session.GetOutputNameAllocated(0, allocator);
+    outputNodeNameAllocatedStrings.push_back(std::move(output_name));
+    outputNames.push_back(outputNodeNameAllocatedStrings.back().get());
+
+
+    // Set the expected input image shape based on the model's input tensor
+    inputImageShape = cv::Size(inputTensorShape[3], inputTensorShape[2]);
+
+    // Get the number of input and output nodes
+    numInputNodes = session.GetInputCount();
+    numOutputNodes = session.GetOutputCount();
+
+    // Load class names and generate corresponding colors
+    classNames = utils::getClassNames(labelsPath);
+    classColors = utils::generateColors(classNames);
+
+    std::cout << "Model loaded successfully with " << numInputNodes << " input nodes and " << numOutputNodes << " output nodes." << std::endl;
+}
+
+// Preprocess function implementation
+cv::Mat YOLO9Detector::preprocess(const cv::Mat &image, float *&blob, std::vector<int64_t> &inputTensorShape) {
+    // Start timing the preprocessing step
+    ScopedTimer timer("Preprocessing");
+
+    cv::Mat resizedImage;
+   
+    // Resize and pad the image using letterBox utility
+    utils::letterBox(image, resizedImage, inputImageShape, cv::Scalar(114, 114, 114), isDynamicInputShape, false, true, 32);
+
+    // Update input tensor shape based on resized image dimensions
+    inputTensorShape[2] = resizedImage.rows;
+    inputTensorShape[3] = resizedImage.cols;
+
+
+    // Convert image to float and normalize to [0, 1]
+    resizedImage.convertTo(resizedImage, CV_32FC3, 1 / 255.0);
+    
+    // Allocate memory for the image blob in CHW format
+    blob = new float[resizedImage.cols * resizedImage.rows * resizedImage.channels()];
+    cv::Size floatImageSize{resizedImage.cols, resizedImage.rows};
+
+    // Split the image into separate channels and store in the blob
+    std::vector<cv::Mat> chw(resizedImage.channels());
+    for (int i = 0; i < resizedImage.channels(); ++i) {
+        chw[i] = cv::Mat(floatImageSize, CV_32FC1, blob + i * floatImageSize.width * floatImageSize.height);
+    }
+    cv::split(resizedImage, chw); // Split channels into the blob
+
+    DEBUG_PRINT("Preprocessing completed");
+
+    return image;
+}
+
+
+std::vector<Detection> YOLO9Detector::postprocess(const cv::Size& originalImageSize, 
+                                                const cv::Size& resizedImageShape,
+                                                std::vector<Ort::Value>& outputTensors) {
+    ScopedTimer timer("Postprocessing");
+    auto* rawOutput = outputTensors[0].GetTensorData<float>();
+    std::vector<int64_t> outputShape = outputTensors[0].GetTensorTypeAndShapeInfo().GetShape();
+    
+    // Expected shape: [1, 84, 8400] where:
+    // - 1: batch size
+    // - 84: 4 box coordinates + 80 class scores
+    // - 8400: number of predictions
+    const int numPredictions = outputShape[2];  // Should be 8400
+    const int numAttributes = outputShape[1];   // Should be 84
+    const int numClasses = numAttributes - 4;   // 80 classes
+
+    std::vector<Detection> detectionVector;
+    detectionVector.reserve(numPredictions);
+
+    for(int i = 0; i < numPredictions; ++i) {
+        // Strided access pattern for [1, 84, 8400] shaped output
+        const float x_center = rawOutput[i + 0 * numPredictions];  // X at stride 0
+        const float y_center = rawOutput[i + 1 * numPredictions];  // Y at stride 1
+        const float width =    rawOutput[i + 2 * numPredictions];  // Width at stride 2
+        const float height =   rawOutput[i + 3 * numPredictions];  // Height at stride 3
+
+        // Find class with maximum score
+        int classId = -1;
+        float maxScore = -FLT_MAX;
+        for(int c = 0; c < numClasses; ++c) {
+            const float score = rawOutput[i + (4 + c) * numPredictions];
+            if(score > maxScore) {
+                maxScore = score;
+                classId = c;
+            }
+        }
+
+        // Filter out low-confidence detections
+        if(maxScore < CONFIDENCE_THRESHOLD) continue;
+
+        // Convert center coordinates to corner coordinates
+        Detection detection(
+            static_cast<int>(x_center - width / 2),  // x1
+            static_cast<int>(y_center - height / 2), // y1
+            static_cast<int>(x_center + width / 2),  // x2
+            static_cast<int>(y_center + height / 2), // y2
+            classId,                                 // class_id
+            maxScore                                 // confidence
+        );
+        
+        // Scale coordinates to original image size (handles letterboxing if needed)
+        utils::scaleResultCoordsToOriginal(resizedImageShape, detection, originalImageSize);
+
+        detectionVector.emplace_back(detection);
+    }
+
+    // Prepare data for NMS
+    std::vector<cv::Rect> boxes;
+    std::vector<float> scores;
+    boxes.reserve(detectionVector.size());
+    scores.reserve(detectionVector.size());
+
+    for(const auto& det : detectionVector) {
+        boxes.emplace_back(cv::Rect(det.x1, det.y1, det.x2 - det.x1, det.y2 - det.y1));
+        scores.push_back(det.confidence);
+    }
+
+    // Apply NMS
+    std::vector<int> indices;
+    cv::dnn::NMSBoxes(boxes, scores, CONFIDENCE_THRESHOLD, NMS_THRESHOLD, indices);
+
+    // Collect final detections
+    std::vector<Detection> finalDetections;
+    finalDetections.reserve(indices.size());
+    for(int idx : indices) {
+        finalDetections.push_back(detectionVector[idx]);
+    }
+
+
+    return finalDetections;
+}
+
+
+// Detect function implementation
+std::vector<Detection> YOLO9Detector::detect(const cv::Mat& image) {
+    // Start timing the overall detection process
+    ScopedTimer timer("Overall detection"); // Commented out for performance
+
+    float* blobPtr = nullptr; // Pointer to hold preprocessed image data
+    
+    // Define the shape of the input tensor (batch size, channels, height, width)
+    std::vector<int64_t> inputTensorShape = {1, 3, inputImageShape.height, inputImageShape.width};
+
+    // Preprocess the image and obtain a pointer to the blob
+    cv::Mat inputImage = preprocess(image, blobPtr, inputTensorShape);
+
+    // Compute the total number of elements in the input tensor
+    size_t inputTensorSize = utils::vectorProduct(inputTensorShape);
+
+    // Create a vector from the blob data for ONNX Runtime input
+    std::vector<float> inputTensorValues(blobPtr, blobPtr + inputTensorSize);
+
+    delete[] blobPtr; // Free the allocated memory for the blob
+
+    // Create an Ort memory info object (can be cached if used repeatedly)
+    static Ort::MemoryInfo memoryInfo = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+
+    // Create input tensor object using the preprocessed data
+    Ort::Value inputTensor = Ort::Value::CreateTensor<float>(
+        memoryInfo,
+        inputTensorValues.data(),
+        inputTensorSize,
+        inputTensorShape.data(),
+        inputTensorShape.size()
+    );
+
+    // Run the inference session with the input tensor and retrieve output tensors
+    std::vector<Ort::Value> outputTensors = session.Run(
+        Ort::RunOptions{nullptr},
+        inputNames.data(),
+        &inputTensor,
+        numInputNodes,
+        outputNames.data(),
+        numOutputNodes
+    );
+
+    // Determine the resized image shape based on input tensor shape
+    cv::Size resizedImageShape(static_cast<int>(inputTensorShape[3]), static_cast<int>(inputTensorShape[2]));
+
+    // Postprocess the output tensors to obtain detections
+    std::vector<Detection> detections = postprocess(image.size(), resizedImageShape, outputTensors);
+
+    return detections; // Return the vector of detections
+}

--- a/include/YOLO9Seg.hpp
+++ b/include/YOLO9Seg.hpp
@@ -1,0 +1,796 @@
+#pragma once
+
+// ====================================================
+// Single YOLOv9 Segmentation and Detection Header File
+// ====================================================
+//
+// This header defines the YOLOv9SegDetector class for performing object detection 
+// and segmentation using the YOLOv9 model. It includes necessary libraries, 
+// utility structures, and helper functions to facilitate model inference 
+// and result post-processing.
+//
+// Author: Mohamed Samir, https://www.linkedin.com/in/mohamed-samir-7a730b237/
+// Date: 31.01.2025
+//
+// ====================================================
+
+
+#include <onnxruntime_cxx_api.h>
+#include <opencv2/opencv.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <numeric>
+#include <random>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+// ============================================================================
+// Debug/Timer Utilities (Optional)
+// ============================================================================
+#ifdef DEBUG
+    #define DEBUG_PRINT(msg) std::cout << "[DEBUG] " << msg << std::endl
+#else
+    #define DEBUG_PRINT(msg) /* no-op */
+#endif
+
+// Simple scoped timer (optional)
+class ScopedTimer {
+public:
+    explicit ScopedTimer(const std::string &name_)
+        : name(name_), start(std::chrono::high_resolution_clock::now()) {}
+    ~ScopedTimer() {
+#ifdef DEBUG
+        auto end = std::chrono::high_resolution_clock::now();
+        double ms = std::chrono::duration<double, std::milli>(end - start).count();
+        std::cout << "[TIMER] " << name << ": " << ms << " ms" << std::endl;
+#endif
+    }
+private:
+    std::string name;
+    std::chrono::time_point<std::chrono::high_resolution_clock> start;
+};
+
+// ============================================================================
+// Constants / Thresholds
+// ============================================================================
+static const float CONFIDENCE_THRESHOLD = 0.40f; // Filter boxes below this confidence
+static const float IOU_THRESHOLD        = 0.45f; // NMS IoU threshold
+static const float MASK_THRESHOLD       = 0.40f; // Slightly lower to capture partial objects
+
+// ============================================================================
+// Structs
+// ============================================================================
+struct BoundingBox {
+    int x{0};
+    int y{0};
+    int width{0};
+    int height{0};
+
+    BoundingBox() = default;
+    BoundingBox(int _x, int _y, int w, int h)
+        : x(_x), y(_y), width(w), height(h) {}
+
+    float area() const { return static_cast<float>(width * height); }
+
+    BoundingBox intersect(const BoundingBox &other) const {
+        int xStart = std::max(x, other.x);
+        int yStart = std::max(y, other.y);
+        int xEnd   = std::min(x + width,  other.x + other.width);
+        int yEnd   = std::min(y + height, other.y + other.height);
+        int iw     = std::max(0, xEnd - xStart);
+        int ih     = std::max(0, yEnd - yStart);
+        return BoundingBox(xStart, yStart, iw, ih);
+    }
+};
+
+struct Segmentation {
+    BoundingBox box;
+    float       conf{0.f};
+    int         classId{0};
+    cv::Mat     mask;  // Single-channel (8UC1) mask in full resolution
+};
+
+// ============================================================================
+// Utility Namespace
+// ============================================================================
+namespace utils {
+
+    template <typename T>
+    T clamp(const T &val, const T &low, const T &high) {
+        return std::max(low, std::min(val, high));
+    }
+
+    inline std::vector<std::string> getClassNames(const std::string &path) {
+        std::vector<std::string> classNames;
+        std::ifstream f(path);
+        if (!f) {
+            std::cerr << "[ERROR] Could not open class names file: " << path << std::endl;
+            return classNames;
+        }
+        std::string line;
+        while (std::getline(f, line)) {
+            if (!line.empty() && line.back() == '\r') {
+                line.pop_back();
+            }
+            classNames.push_back(line);
+        }
+        DEBUG_PRINT("Loaded " << classNames.size() << " class names from " << path);
+        return classNames;
+    }
+
+    inline size_t vectorProduct(const std::vector<int64_t> &shape) {
+        return std::accumulate(shape.begin(), shape.end(), 1ull, std::multiplies<size_t>());
+    }
+
+    inline void letterBox(const cv::Mat &image,
+                          cv::Mat &outImage,
+                          const cv::Size &newShape,
+                          const cv::Scalar &color     = cv::Scalar(114, 114, 114),
+                          bool auto_       = true,
+                          bool scaleFill   = false,
+                          bool scaleUp     = true,
+                          int stride       = 32) {
+        float r = std::min((float)newShape.height / (float)image.rows,
+                           (float)newShape.width  / (float)image.cols);
+        if (!scaleUp) {
+            r = std::min(r, 1.0f);
+        }
+
+        int newW = static_cast<int>(std::round(image.cols * r));
+        int newH = static_cast<int>(std::round(image.rows * r));
+
+        int dw = newShape.width  - newW;
+        int dh = newShape.height - newH;
+
+        if (auto_) {
+            dw = dw % stride;
+            dh = dh % stride;
+        }
+        else if (scaleFill) {
+            newW = newShape.width;
+            newH = newShape.height;
+            dw = 0;
+            dh = 0;
+        }
+
+        cv::Mat resized;
+        cv::resize(image, resized, cv::Size(newW, newH), 0, 0, cv::INTER_LINEAR);
+
+        int top = dh / 2;
+        int bottom = dh - top;
+        int left = dw / 2;
+        int right = dw - left;
+        cv::copyMakeBorder(resized, outImage, top, bottom, left, right, cv::BORDER_CONSTANT, color);
+    }
+
+    inline BoundingBox scaleCoords(const cv::Size &letterboxShape,
+                                   const BoundingBox &coords,
+                                   const cv::Size &originalShape,
+                                   bool p_Clip = true) {
+        float gain = std::min((float)letterboxShape.height / (float)originalShape.height,
+                              (float)letterboxShape.width  / (float)originalShape.width);
+
+        int padW = static_cast<int>(std::round(((float)letterboxShape.width  - (float)originalShape.width  * gain) / 2.f));
+        int padH = static_cast<int>(std::round(((float)letterboxShape.height - (float)originalShape.height * gain) / 2.f));
+
+        BoundingBox ret;
+        ret.x      = static_cast<int>(std::round(((float)coords.x      - (float)padW) / gain));
+        ret.y      = static_cast<int>(std::round(((float)coords.y      - (float)padH) / gain));
+        ret.width  = static_cast<int>(std::round((float)coords.width   / gain));
+        ret.height = static_cast<int>(std::round((float)coords.height  / gain));
+
+        if (p_Clip) {
+            ret.x = clamp(ret.x, 0, originalShape.width);
+            ret.y = clamp(ret.y, 0, originalShape.height);
+            ret.width  = clamp(ret.width,  0, originalShape.width  - ret.x);
+            ret.height = clamp(ret.height, 0, originalShape.height - ret.y);
+        }
+
+        return ret;
+    }
+
+    inline std::vector<cv::Scalar> generateColors(const std::vector<std::string> &classNames, int seed = 42) {
+        static std::unordered_map<size_t, std::vector<cv::Scalar>> cache;
+        size_t key = 0;
+        for (const auto &name : classNames) {
+            size_t h = std::hash<std::string>{}(name);
+            key ^= (h + 0x9e3779b9 + (key << 6) + (key >> 2));
+        }
+        auto it = cache.find(key);
+        if (it != cache.end()) {
+            return it->second;
+        }
+        std::mt19937 rng(seed);
+        std::uniform_int_distribution<int> dist(0, 255);
+        std::vector<cv::Scalar> colors;
+        colors.reserve(classNames.size());
+        for (size_t i = 0; i < classNames.size(); ++i) {
+            colors.emplace_back(cv::Scalar(dist(rng), dist(rng), dist(rng)));
+        }
+        cache[key] = colors;
+        return colors;
+    }
+
+
+
+    cv::Mat sigmoid(const cv::Mat& src) {
+        cv::Mat dst;
+        cv::exp(-src, dst);
+        dst = 1.0 / (1.0 + dst);
+        return dst;
+    }
+        inline void NMSBoxes(const std::vector<BoundingBox> &boxes,
+                         const std::vector<float> &scores,
+                         float scoreThreshold,
+                         float nmsThreshold,
+                         std::vector<int> &indices) {
+        indices.clear();
+        if (boxes.empty()) {
+            return;
+        }
+
+        std::vector<int> order;
+        order.reserve(boxes.size());
+        for (size_t i = 0; i < boxes.size(); ++i) {
+            if (scores[i] >= scoreThreshold) {
+                order.push_back((int)i);
+            }
+        }
+        if (order.empty()) return;
+
+        std::sort(order.begin(), order.end(),
+                  [&scores](int a, int b) {
+                      return scores[a] > scores[b];
+                  });
+
+        std::vector<float> areas(boxes.size());
+        for (size_t i = 0; i < boxes.size(); ++i) {
+            areas[i] = (float)(boxes[i].width * boxes[i].height);
+        }
+
+        std::vector<bool> suppressed(boxes.size(), false);
+        for (size_t i = 0; i < order.size(); ++i) {
+            int idx = order[i];
+            if (suppressed[idx]) continue;
+
+            indices.push_back(idx);
+
+            for (size_t j = i + 1; j < order.size(); ++j) {
+                int idx2 = order[j];
+                if (suppressed[idx2]) continue;
+
+                const BoundingBox &a = boxes[idx];
+                const BoundingBox &b = boxes[idx2];
+                int interX1 = std::max(a.x, b.x);
+                int interY1 = std::max(a.y, b.y);
+                int interX2 = std::min(a.x + a.width,  b.x + b.width);
+                int interY2 = std::min(a.y + a.height, b.y + b.height);
+
+                int w = interX2 - interX1;
+                int h = interY2 - interY1;
+                if (w > 0 && h > 0) {
+                    float interArea = (float)(w * h);
+                    float unionArea = areas[idx] + areas[idx2] - interArea;
+                    float iou = (unionArea > 0.f)? (interArea / unionArea) : 0.f;
+                    if (iou > nmsThreshold) {
+                        suppressed[idx2] = true;
+                    }
+                }
+            }
+        }
+    }
+
+} // namespace utils
+
+// ============================================================================
+// YOLOv9SegDetector Class
+// ============================================================================
+class YOLOv9SegDetector {
+public:
+    YOLOv9SegDetector(const std::string &modelPath,
+                      const std::string &labelsPath,
+                      bool useGPU = false);
+
+    // Main API
+    std::vector<Segmentation> segment(const cv::Mat &image,
+                                      float confThreshold = CONFIDENCE_THRESHOLD,
+                                      float iouThreshold  = IOU_THRESHOLD);
+
+    // Draw results
+    void drawSegmentationsAndBoxes(cv::Mat &image,
+                           const std::vector<Segmentation> &results,
+                           float maskAlpha = 0.5f) const;
+
+    void drawSegmentations(cv::Mat &image,
+                           const std::vector<Segmentation> &results,
+                           float maskAlpha = 0.5f) const;
+    // Accessors
+    const std::vector<std::string> &getClassNames()  const { return classNames;  }
+    const std::vector<cv::Scalar>  &getClassColors() const { return classColors; }
+
+private:
+    Ort::Env           env;
+    Ort::SessionOptions sessionOptions;
+    Ort::Session       session{nullptr};
+
+    bool     isDynamicInputShape{false};
+    cv::Size inputImageShape; 
+
+    std::vector<Ort::AllocatedStringPtr> inputNameAllocs;
+    std::vector<const char*>             inputNames;
+    std::vector<Ort::AllocatedStringPtr> outputNameAllocs;
+    std::vector<const char*>             outputNames;
+
+    size_t numInputNodes  = 0;
+    size_t numOutputNodes = 0;
+
+    std::vector<std::string> classNames;
+    std::vector<cv::Scalar>  classColors;
+
+    // Helpers
+    cv::Mat preprocess(const cv::Mat &image,
+                       float *&blobPtr,
+                       std::vector<int64_t> &inputTensorShape);
+
+    std::vector<Segmentation> postprocess(const cv::Size &origSize,
+                                          const cv::Size &letterboxSize,
+                                          const std::vector<Ort::Value> &outputs,
+                                          float confThreshold,
+                                          float iouThreshold);
+};
+
+inline YOLOv9SegDetector::YOLOv9SegDetector(const std::string &modelPath,
+                                            const std::string &labelsPath,
+                                            bool useGPU)
+    : env(ORT_LOGGING_LEVEL_WARNING, "YOLOv9Seg") 
+{
+    ScopedTimer timer("YOLOv9SegDetector Constructor");
+
+    sessionOptions.SetIntraOpNumThreads(std::min(6, static_cast<int>(std::thread::hardware_concurrency())));
+    sessionOptions.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_ALL);
+
+    std::vector<std::string> providers = Ort::GetAvailableProviders();
+    if (useGPU && std::find(providers.begin(), providers.end(), "CUDAExecutionProvider") != providers.end()) {
+        OrtCUDAProviderOptions cudaOptions;
+        sessionOptions.AppendExecutionProvider_CUDA(cudaOptions);
+        std::cout << "[INFO] Using GPU (CUDA) for YOLOv9 Seg inference.\n";
+    } else {
+        std::cout << "[INFO] Using CPU for YOLOv9 Seg inference.\n";
+    }
+
+#ifdef _WIN32
+    std::wstring w_modelPath(modelPath.begin(), modelPath.end());
+    session = Ort::Session(env, w_modelPath.c_str(), sessionOptions);
+#else
+    session = Ort::Session(env, modelPath.c_str(), sessionOptions);
+#endif
+
+    numInputNodes  = session.GetInputCount();
+    numOutputNodes = session.GetOutputCount();
+
+    Ort::AllocatorWithDefaultOptions allocator;
+
+    // Input
+    {
+        auto inNameAlloc = session.GetInputNameAllocated(0, allocator);
+        inputNameAllocs.emplace_back(std::move(inNameAlloc));
+        inputNames.push_back(inputNameAllocs.back().get());
+
+        auto inTypeInfo = session.GetInputTypeInfo(0);
+        auto inShape    = inTypeInfo.GetTensorTypeAndShapeInfo().GetShape();
+
+        if (inShape.size() == 4) {
+            if (inShape[2] == -1 || inShape[3] == -1) {
+                isDynamicInputShape = true;
+                inputImageShape = cv::Size(640, 640); // Fallback if dynamic
+            } else {
+                inputImageShape = cv::Size(static_cast<int>(inShape[3]), static_cast<int>(inShape[2]));
+            }
+        } else {
+            throw std::runtime_error("Model input is not 4D! Expect [N, C, H, W].");
+        }
+    }
+
+    // Outputs
+    if (numOutputNodes != 2) {
+        throw std::runtime_error("Expected exactly 2 output nodes: output0 and output1.");
+    }
+
+    for (size_t i = 0; i < numOutputNodes; ++i) {
+        auto outNameAlloc = session.GetOutputNameAllocated(i, allocator);
+        outputNameAllocs.emplace_back(std::move(outNameAlloc));
+        outputNames.push_back(outputNameAllocs.back().get());
+    }
+
+    classNames  = utils::getClassNames(labelsPath);
+    classColors = utils::generateColors(classNames);
+
+    std::cout << "[INFO] YOLOv9Seg loaded: " << modelPath << std::endl
+              << "      Input shape: " << inputImageShape 
+              << (isDynamicInputShape ? " (dynamic)" : "") << std::endl
+              << "      #Outputs   : " << numOutputNodes << std::endl
+              << "      #Classes   : " << classNames.size() << std::endl;
+}
+
+inline cv::Mat YOLOv9SegDetector::preprocess(const cv::Mat &image,
+                                             float *&blobPtr,
+                                             std::vector<int64_t> &inputTensorShape) 
+{
+    ScopedTimer timer("Preprocess");
+
+    cv::Mat letterboxImage;
+    utils::letterBox(image, letterboxImage, inputImageShape,
+                     cv::Scalar(114,114,114), /*auto_=*/isDynamicInputShape,
+                     /*scaleFill=*/false, /*scaleUp=*/true, /*stride=*/32);
+
+    // Update if dynamic
+    inputTensorShape[2] = static_cast<int64_t>(letterboxImage.rows);
+    inputTensorShape[3] = static_cast<int64_t>(letterboxImage.cols);
+
+    letterboxImage.convertTo(letterboxImage, CV_32FC3, 1.0f/255.0f);
+
+    size_t size = static_cast<size_t>(letterboxImage.rows) * static_cast<size_t>(letterboxImage.cols) * 3;
+    blobPtr = new float[size];
+
+    std::vector<cv::Mat> channels(3);
+    for (int c = 0; c < 3; ++c) {
+        channels[c] = cv::Mat(letterboxImage.rows, letterboxImage.cols, CV_32FC1,
+                              blobPtr + c * (letterboxImage.rows * letterboxImage.cols));
+    }
+    cv::split(letterboxImage, channels);
+
+    return letterboxImage;
+}
+
+std::vector<Segmentation> YOLOv9SegDetector::postprocess(
+    const cv::Size &origSize,
+    const cv::Size &letterboxSize,
+    const std::vector<Ort::Value> &outputs,
+    float confThreshold,
+    float iouThreshold) 
+{
+    ScopedTimer timer("PostprocessSeg"); 
+
+    std::vector<Segmentation> results;
+
+    // Validate outputs size
+    if (outputs.size() < 2) {
+        throw std::runtime_error("Insufficient outputs from the model. Expected at least 2 outputs.");
+    }
+
+    // Extract outputs
+    const float* output0_ptr = outputs[0].GetTensorData<float>();
+    const float* output1_ptr = outputs[1].GetTensorData<float>();
+
+    // Get shapes
+    auto shape0 = outputs[0].GetTensorTypeAndShapeInfo().GetShape(); // [1, 116, num_detections]
+    auto shape1 = outputs[1].GetTensorTypeAndShapeInfo().GetShape(); // [1, 32, maskH, maskW]
+
+    if (shape1.size() != 4 || shape1[0] != 1 || shape1[1] != 32)
+        throw std::runtime_error("Unexpected output1 shape. Expected [1, 32, maskH, maskW].");
+
+    const size_t num_features = shape0[1]; // e.g 80 class + 4 bbox parms + 32 seg masks = 116 
+    const size_t num_detections = shape0[2];
+
+    // Early exit if no detections
+    if (num_detections == 0)
+    {
+        return results;
+    }
+
+    const int numClasses = static_cast<int>(num_features - 4 - 32); // Corrected number of classes
+
+    // Validate numClasses
+    if (numClasses <= 0)
+    {
+        throw std::runtime_error("Invalid number of classes.");
+    }
+
+    const int numBoxes = static_cast<int>(num_detections);
+    const int maskH = static_cast<int>(shape1[2]);
+    const int maskW = static_cast<int>(shape1[3]);
+
+    // Constants from model architecture
+    constexpr int BOX_OFFSET = 0;
+    constexpr int CLASS_CONF_OFFSET = 4;
+    const int MASK_COEFF_OFFSET = numClasses + CLASS_CONF_OFFSET;
+
+    // 1. Process prototype masks
+    // Store all prototype masks in a vector for easy access
+    std::vector<cv::Mat> prototypeMasks;
+    prototypeMasks.reserve(32);
+    for (int m = 0; m < 32; ++m) {
+        // Each mask is maskH x maskW
+        cv::Mat proto(maskH, maskW, CV_32F, const_cast<float*>(output1_ptr + m * maskH * maskW));
+        prototypeMasks.emplace_back(proto.clone()); // Clone to ensure data integrity
+    }
+
+    // 2. Process detections
+    std::vector<BoundingBox> boxes;
+    boxes.reserve(numBoxes);
+    std::vector<float> confidences;
+    confidences.reserve(numBoxes);
+    std::vector<int> classIds;
+    classIds.reserve(numBoxes);
+    std::vector<std::vector<float>> maskCoefficientsList;
+    maskCoefficientsList.reserve(numBoxes);
+
+    for (int i = 0; i < numBoxes; ++i) {
+        // Extract box coordinates
+        float xc = output0_ptr[BOX_OFFSET * numBoxes + i];
+        float yc = output0_ptr[(BOX_OFFSET + 1) * numBoxes + i];
+        float w = output0_ptr[(BOX_OFFSET + 2) * numBoxes + i];
+        float h = output0_ptr[(BOX_OFFSET + 3) * numBoxes + i];
+
+        // Convert to xyxy format
+        BoundingBox box{
+            static_cast<int>(std::round(xc - w / 2.0f)),
+            static_cast<int>(std::round(yc - h / 2.0f)),
+            static_cast<int>(std::round(w)),
+            static_cast<int>(std::round(h))
+        };
+
+        // Get class confidence
+        float maxConf = 0.0f;
+        int classId = -1;
+        for (int c = 0; c < numClasses; ++c) {
+            float conf = output0_ptr[(CLASS_CONF_OFFSET + c) * numBoxes + i];
+            if (conf > maxConf) {
+                maxConf = conf;
+                classId = c;
+            }
+        }
+
+        if (maxConf < confThreshold) continue;
+
+        // Store detection
+        boxes.push_back(box);
+        confidences.push_back(maxConf);
+        classIds.push_back(classId);
+
+        // Store mask coefficients
+        std::vector<float> maskCoeffs(32);
+        for (int m = 0; m < 32; ++m) {
+            maskCoeffs[m] = output0_ptr[(MASK_COEFF_OFFSET + m) * numBoxes + i];
+        }
+        maskCoefficientsList.emplace_back(std::move(maskCoeffs));
+    }
+
+    // Early exit if no boxes after confidence threshold
+    if (boxes.empty()) {
+        return results;
+    }
+
+    // 3. Apply NMS
+    std::vector<int> nmsIndices;
+    utils::NMSBoxes(boxes, confidences, confThreshold, iouThreshold, nmsIndices);
+
+    if (nmsIndices.empty()) {
+        return results;
+    }
+
+    // 4. Prepare final results
+    results.reserve(nmsIndices.size());
+
+    // Calculate letterbox parameters
+    const float gain = std::min(static_cast<float>(letterboxSize.height) / origSize.height,
+                               static_cast<float>(letterboxSize.width) / origSize.width);
+    const int scaledW = static_cast<int>(origSize.width * gain);
+    const int scaledH = static_cast<int>(origSize.height * gain);
+    const float padW = (letterboxSize.width - scaledW) / 2.0f;
+    const float padH = (letterboxSize.height - scaledH) / 2.0f;
+
+    // Precompute mask scaling factors
+    const float maskScaleX = static_cast<float>(maskW) / letterboxSize.width;
+    const float maskScaleY = static_cast<float>(maskH) / letterboxSize.height;
+
+    for (const int idx : nmsIndices) {
+        Segmentation seg;
+        seg.box = boxes[idx];
+        seg.conf = confidences[idx];
+        seg.classId = classIds[idx];
+
+        // 5. Scale box to original image
+        seg.box = utils::scaleCoords(letterboxSize, seg.box, origSize, true);
+
+        // 6. Process mask
+        const auto& maskCoeffs = maskCoefficientsList[idx];
+
+        // Linear combination of prototype masks
+        cv::Mat finalMask = cv::Mat::zeros(maskH, maskW, CV_32F);
+        for (int m = 0; m < 32; ++m) {
+            finalMask += maskCoeffs[m] * prototypeMasks[m];
+        }
+
+        // Apply sigmoid activation
+        finalMask = utils::sigmoid(finalMask);
+
+        // Crop mask to letterbox area with a slight padding to avoid border issues
+        int x1 = static_cast<int>(std::round((padW - 0.1f) * maskScaleX));
+        int y1 = static_cast<int>(std::round((padH - 0.1f) * maskScaleY));
+        int x2 = static_cast<int>(std::round((letterboxSize.width - padW + 0.1f) * maskScaleX));
+        int y2 = static_cast<int>(std::round((letterboxSize.height - padH + 0.1f) * maskScaleY));
+
+        // Ensure coordinates are within mask bounds
+        x1 = std::max(0, std::min(x1, maskW - 1));
+        y1 = std::max(0, std::min(y1, maskH - 1));
+        x2 = std::max(x1, std::min(x2, maskW));
+        y2 = std::max(y1, std::min(y2, maskH));
+
+        // Handle cases where cropping might result in zero area
+        if (x2 <= x1 || y2 <= y1) {
+            // Skip this mask as cropping is invalid
+            continue;
+        }
+
+        cv::Rect cropRect(x1, y1, x2 - x1, y2 - y1);
+        cv::Mat croppedMask = finalMask(cropRect).clone(); // Clone to ensure data integrity
+
+        // Resize to original dimensions
+        cv::Mat resizedMask;
+        cv::resize(croppedMask, resizedMask, origSize, 0, 0, cv::INTER_LINEAR);
+
+        // Threshold and convert to binary
+        cv::Mat binaryMask;
+        cv::threshold(resizedMask, binaryMask, 0.5, 255.0, cv::THRESH_BINARY);
+        binaryMask.convertTo(binaryMask, CV_8U);
+
+        // Crop to bounding box
+        cv::Mat finalBinaryMask = cv::Mat::zeros(origSize, CV_8U);
+        cv::Rect roi(seg.box.x, seg.box.y, seg.box.width, seg.box.height);
+        roi &= cv::Rect(0, 0, binaryMask.cols, binaryMask.rows); // Ensure ROI is within mask
+        if (roi.area() > 0) {
+            binaryMask(roi).copyTo(finalBinaryMask(roi));
+        }
+
+        seg.mask = finalBinaryMask;
+        results.push_back(seg);
+    }
+
+    return results;
+}
+
+inline void YOLOv9SegDetector::drawSegmentationsAndBoxes(cv::Mat &image,
+                                                 const std::vector<Segmentation> &results,
+                                                 float maskAlpha) const 
+{
+    for (const auto &seg : results) {
+        if (seg.conf < CONFIDENCE_THRESHOLD) {
+            continue;
+        }
+        cv::Scalar color = classColors[seg.classId % classColors.size()];
+
+        // -----------------------------
+        // 1. Draw Bounding Box
+        // -----------------------------
+        cv::rectangle(image,
+                      cv::Point(seg.box.x, seg.box.y),
+                      cv::Point(seg.box.x + seg.box.width, seg.box.y + seg.box.height),
+                      color, 2);
+
+        // -----------------------------
+        // 2. Draw Label
+        // -----------------------------
+        std::string label = classNames[seg.classId] + " " + std::to_string(static_cast<int>(seg.conf * 100)) + "%";
+        int baseLine = 0;
+        double fontScale = 0.5;
+        int thickness = 1;
+        cv::Size labelSize = cv::getTextSize(label, cv::FONT_HERSHEY_SIMPLEX, fontScale, thickness, &baseLine);
+        int top = std::max(seg.box.y, labelSize.height + 5);
+        cv::rectangle(image,
+                      cv::Point(seg.box.x, top - labelSize.height - 5),
+                      cv::Point(seg.box.x + labelSize.width + 5, top),
+                      color, cv::FILLED);
+        cv::putText(image, label,
+                    cv::Point(seg.box.x + 2, top - 2),
+                    cv::FONT_HERSHEY_SIMPLEX,
+                    fontScale,
+                    cv::Scalar(255, 255, 255),
+                    thickness);
+
+        // -----------------------------
+        // 3. Apply Segmentation Mask
+        // -----------------------------
+        if (!seg.mask.empty()) {
+            // Ensure the mask is single-channel
+            cv::Mat mask_gray;
+            if (seg.mask.channels() == 3) {
+                cv::cvtColor(seg.mask, mask_gray, cv::COLOR_BGR2GRAY);
+            } else {
+                mask_gray = seg.mask.clone();
+            }
+
+            // Threshold the mask to binary (object: 255, background: 0)
+            cv::Mat mask_binary;
+            cv::threshold(mask_gray, mask_binary, 127, 255, cv::THRESH_BINARY);
+
+            // Create a colored version of the mask
+            cv::Mat colored_mask;
+            cv::cvtColor(mask_binary, colored_mask, cv::COLOR_GRAY2BGR);
+            colored_mask.setTo(color, mask_binary); // Apply color where mask is present
+
+            // Blend the colored mask with the original image
+            cv::addWeighted(image, 1.0, colored_mask, maskAlpha, 0, image);
+        }
+    }
+}
+
+
+inline void YOLOv9SegDetector::drawSegmentations(cv::Mat &image,
+                                                 const std::vector<Segmentation> &results,
+                                                 float maskAlpha) const 
+{
+    for (const auto &seg : results) {
+        if (seg.conf < CONFIDENCE_THRESHOLD) {
+            continue;
+        }
+        cv::Scalar color = classColors[seg.classId % classColors.size()];
+
+        // -----------------------------
+        // Draw Segmentation Mask Only
+        // -----------------------------
+        if (!seg.mask.empty()) {
+            // Ensure the mask is single-channel
+            cv::Mat mask_gray;
+            if (seg.mask.channels() == 3) {
+                cv::cvtColor(seg.mask, mask_gray, cv::COLOR_BGR2GRAY);
+            } else {
+                mask_gray = seg.mask.clone();
+            }
+
+            // Threshold the mask to binary (object: 255, background: 0)
+            cv::Mat mask_binary;
+            cv::threshold(mask_gray, mask_binary, 127, 255, cv::THRESH_BINARY);
+
+            // Create a colored version of the mask
+            cv::Mat colored_mask;
+            cv::cvtColor(mask_binary, colored_mask, cv::COLOR_GRAY2BGR);
+            colored_mask.setTo(color, mask_binary); // Apply color where mask is present
+
+            // Blend the colored mask with the original image
+            cv::addWeighted(image, 1.0, colored_mask, maskAlpha, 0, image);
+        }
+    }
+}
+
+inline std::vector<Segmentation> YOLOv9SegDetector::segment(const cv::Mat &image,
+                                                            float confThreshold,
+                                                            float iouThreshold) 
+{
+    ScopedTimer timer("YOLOv9Seg: segment()");
+
+    float *blobPtr = nullptr;
+    std::vector<int64_t> inputShape = {1, 3, inputImageShape.height, inputImageShape.width};
+    cv::Mat letterboxImg = preprocess(image, blobPtr, inputShape);
+
+    size_t inputSize = utils::vectorProduct(inputShape);
+    std::vector<float> inputVals(blobPtr, blobPtr + inputSize);
+    delete[] blobPtr;
+
+    Ort::MemoryInfo memInfo = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+    Ort::Value inputTensor = Ort::Value::CreateTensor<float>(
+        memInfo,
+        inputVals.data(),
+        inputSize,
+        inputShape.data(),
+        inputShape.size()
+    );
+
+    std::vector<Ort::Value> outputs = session.Run(
+        Ort::RunOptions{nullptr},
+        inputNames.data(),
+        &inputTensor,
+        numInputNodes,
+        outputNames.data(),
+        numOutputNodes);
+
+    cv::Size letterboxSize(static_cast<int>(inputShape[3]), static_cast<int>(inputShape[2]));
+    return postprocess(image.size(), letterboxSize, outputs, confThreshold, iouThreshold);
+}
+

--- a/models/export_onnx.py
+++ b/models/export_onnx.py
@@ -1,7 +1,7 @@
 from ultralytics import YOLO
 
 # Load the YOLOv9s model
-model = YOLO("yolo11n.pt")
+model = YOLO("yolov9c-seg.pt")
 
 # Export the model to ONNX format
 model.export(format = "onnx")

--- a/models/export_onnx.py
+++ b/models/export_onnx.py
@@ -1,7 +1,7 @@
 from ultralytics import YOLO
 
-# Load the YOLOv11n model
-model = YOLO("yolo11l.pt")
+# Load the YOLOv9s model
+model = YOLO("yolov9s.pt")
 
 # Export the model to ONNX format
-model.export(format="onnx")
+model.export(format = "onnx")

--- a/models/export_onnx.py
+++ b/models/export_onnx.py
@@ -1,7 +1,7 @@
 from ultralytics import YOLO
 
 # Load the YOLOv9s model
-model = YOLO("yolov9s.pt")
+model = YOLO("yolo11n.pt")
 
 # Export the model to ONNX format
 model.export(format = "onnx")

--- a/src/image_inference.cpp
+++ b/src/image_inference.cpp
@@ -1,9 +1,9 @@
 /**
  * @file image_inference.cpp
- * @brief Object detection in a static image using YOLO models (v5, v7, v8, v10).
+ * @brief Object detection in a static image using YOLO models (v5, v7, v8, v9, v10).
  * 
  * This file implements an object detection application that utilizes YOLO 
- * (You Only Look Once) models, specifically versions 5, 7, 8, and 10. 
+ * (You Only Look Once) models, specifically versions 5, 7, 8, 9, and 10. 
  * The application loads a specified image, processes it to detect objects, 
  * and displays the results with bounding boxes around detected objects.
  *
@@ -44,15 +44,16 @@
 // #include "YOLO5.hpp"  // Uncomment for YOLOv5
 // #include "YOLO7.hpp"  // Uncomment for YOLOv7
 // #include "YOLO8.hpp"  // Uncomment for YOLOv8
+#include "YOLO9.hpp"  // Uncomment for YOLOv9
 // #include "YOLO10.hpp" // Uncomment for YOLOv10
-#include "YOLO11.hpp" // Uncomment for YOLOv11
+// #include "YOLO11.hpp" // Uncomment for YOLOv11
 
 int main()
 {
 
     // Paths to the model, labels, and test image
     const std::string labelsPath = "../models/coco.names";
-    const std::string imagePath = "../data/dogs.jpg";           // Primary image path
+    const std::string imagePath = "../data/dog.jpg";           // Primary image path
 
     // Uncomment the desired image path for testing
     // const std::string imagePath = "../data/happy_dogs.jpg";  // Alternate image
@@ -63,16 +64,19 @@ int main()
     // const std::string modelPath = "../models/yolo5-n6.onnx";      // YOLOv5
     // const std::string modelPath = "../models/yolo7-tiny.onnx";       // YOLOv7
     // const std::string modelPath = "../models/yolo8n.onnx"; // YOLOv8
-    // const std::string modelPath = "../quantized_models/yolo10n_uint8.onnx"; // Quantized YOLOv10 
-    const std::string modelPath = "../models/yolo11n.onnx"; // YOLOv11 
+    const std::string modelPath = "../models/yolov9s.onnx"; // YOLOv9 
+    // const std::string modelPath = "../models/yolo10n.onnx"; // YOLOv10 
+    // const std::string modelPath = "../quantized_models/yolo10n_uint8.onnx"; // Quantized YOLOv10
+    // const std::string modelPath = "../models/yolo11n.onnx"; // YOLOv11 
 
     // Initialize the YOLO detector with the chosen model and labels
-    bool isGPU = true; // Set to false for CPU processing
+    bool isGPU = false; // Set to false for CPU processing
     // YOLO7Detector detector(modelPath, labelsPath, isGPU);
     // YOLO5Detector detector(modelPath, labelsPath, isGPU);  // Uncomment for YOLOv5
     // YOLO8Detector detector(modelPath, labelsPath, isGPU);  // Uncomment for YOLOv8
+    YOLO9Detector detector(modelPath, labelsPath, isGPU); // Uncomment for YOLOv9
     // YOLO10Detector detector(modelPath, labelsPath, isGPU); // Uncomment for YOLOv10
-    YOLO11Detector detector(modelPath, labelsPath, isGPU); // Uncomment for YOLOv11
+    // YOLO11Detector detector(modelPath, labelsPath, isGPU); // Uncomment for YOLOv11
 
     // Load an image
     cv::Mat image = cv::imread(imagePath);
@@ -81,6 +85,8 @@ int main()
         std::cerr << "Error: Could not open or find the image!\n";
         return -1;
     }
+
+    
 
     // Detect objects in the image and measure execution time
     auto start = std::chrono::high_resolution_clock::now();

--- a/src/image_inference.cpp
+++ b/src/image_inference.cpp
@@ -44,9 +44,9 @@
 // #include "YOLO5.hpp"  // Uncomment for YOLOv5
 // #include "YOLO7.hpp"  // Uncomment for YOLOv7
 // #include "YOLO8.hpp"  // Uncomment for YOLOv8
-#include "YOLO9.hpp"  // Uncomment for YOLOv9
+// #include "YOLO9.hpp"  // Uncomment for YOLOv9
 // #include "YOLO10.hpp" // Uncomment for YOLOv10
-// #include "YOLO11.hpp" // Uncomment for YOLOv11
+#include "YOLO11.hpp" // Uncomment for YOLOv11
 
 int main()
 {
@@ -64,19 +64,19 @@ int main()
     // const std::string modelPath = "../models/yolo5-n6.onnx";      // YOLOv5
     // const std::string modelPath = "../models/yolo7-tiny.onnx";       // YOLOv7
     // const std::string modelPath = "../models/yolo8n.onnx"; // YOLOv8
-    const std::string modelPath = "../models/yolov9s.onnx"; // YOLOv9 
+    // const std::string modelPath = "../models/yolov9s.onnx"; // YOLOv9 
     // const std::string modelPath = "../models/yolo10n.onnx"; // YOLOv10 
     // const std::string modelPath = "../quantized_models/yolo10n_uint8.onnx"; // Quantized YOLOv10
-    // const std::string modelPath = "../models/yolo11n.onnx"; // YOLOv11 
+    const std::string modelPath = "../models/yolo11n.onnx"; // YOLOv11 
 
     // Initialize the YOLO detector with the chosen model and labels
     bool isGPU = false; // Set to false for CPU processing
     // YOLO7Detector detector(modelPath, labelsPath, isGPU);
     // YOLO5Detector detector(modelPath, labelsPath, isGPU);  // Uncomment for YOLOv5
     // YOLO8Detector detector(modelPath, labelsPath, isGPU);  // Uncomment for YOLOv8
-    YOLO9Detector detector(modelPath, labelsPath, isGPU); // Uncomment for YOLOv9
+    // YOLO9Detector detector(modelPath, labelsPath, isGPU); // Uncomment for YOLOv9
     // YOLO10Detector detector(modelPath, labelsPath, isGPU); // Uncomment for YOLOv10
-    // YOLO11Detector detector(modelPath, labelsPath, isGPU); // Uncomment for YOLOv11
+    YOLO11Detector detector(modelPath, labelsPath, isGPU); // Uncomment for YOLOv11
 
     // Load an image
     cv::Mat image = cv::imread(imagePath);

--- a/src/video_inference.cpp
+++ b/src/video_inference.cpp
@@ -1,9 +1,9 @@
 /**
  * @file video_inference.cpp
- * @brief Object detection in a video stream using YOLO models (v5, v7, v8, v10).
+ * @brief Object detection in a video stream using YOLO models (v5, v7, v8, v9, v10).
  * 
  * This file implements an object detection application that utilizes YOLO 
- * (You Only Look Once) models, specifically versions 5, 7, 8, and 10. 
+ * (You Only Look Once) models, specifically versions 5, 7, 8, 9, and 10. 
  * The application processes a video stream to detect objects and saves 
  * the results to a new video file with bounding boxes around detected objects.
  *
@@ -50,8 +50,9 @@
 // #include "YOLO5.hpp"  // Uncomment for YOLOv5
 // #include "YOLO7.hpp"  // Uncomment for YOLOv7
 // #include "YOLO8.hpp"  // Uncomment for YOLOv8
+#include "YOLO9.hpp"  // Uncomment for YOLOv9
 // #include "YOLO10.hpp" // Uncomment for YOLOv10
-#include "YOLO11.hpp" // Uncomment for YOLOv10
+// #include "YOLO11.hpp" // Uncomment for YOLOv10
 
 // Thread-safe queue implementation
 template <typename T>
@@ -99,11 +100,13 @@ int main()
     const std::string outputPath = "../data/SIG_experience_center_processed.mp4"; // Output video path
 
     // Model paths for different YOLO versions
-    const std::string modelPath = "../models/yolo11n.onnx"; // YOLOv11
+    const std::string modelPath = "../models/yolov9s.onnx"; // YOLOv9
+    // const std::string modelPath = "../models/yolo11n.onnx"; // YOLOv11
 
     // Initialize the YOLO detector
-    bool isGPU = true; // Set to false for CPU processing
-    YOLO11Detector detector(modelPath, labelsPath, isGPU); // YOLOv11
+    bool isGPU = false; // Set to false for CPU processing
+    YOLO9Detector detector(modelPath, labelsPath, isGPU); // YOLOv9
+    // YOLO11Detector detector(modelPath, labelsPath, isGPU); // YOLOv11
 
     // Open the video file
     cv::VideoCapture cap(videoPath);


### PR DESCRIPTION
Sorry for the many pull requests—haha!

I was reviewing the segmentation header and thought it might work for the YOLOv9 model as well. So, I copied and pasted your YOLO11Seg segmentation header file into a new file for YOLO9Seg, adjusted the names, and it worked! Now the repo supports YOLOv9 segmentation too.

I used the yolov9c-seg.pt model for conversion to ONNX, and I utilized the same export.py file you provided—I only changed the model name.

![Screenshot from 2025-01-31 04-52-08](https://github.com/user-attachments/assets/957bdb26-b663-4944-9ad5-3274c569a4bd)

I also fixed a small typo in the Segmentation Example section of the README:

-     Changed detector to segmentor
-     Changed img to image

![Screenshot from 2025-01-31 05-03-41](https://github.com/user-attachments/assets/4b4fd2fc-6a5f-4634-b1ea-783b7ec1f97b)
