### PR TITLE
Fix :  Archive extension and ONNXRUNTIME_DIR name in GPU mode

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -37,12 +37,15 @@ architecture=$(uname -m)
 case "$platform" in
 Darwin*)
     ONNXRUNTIME_PLATFORM="osx"
+	ONNXRUNTIME_ARCHIVE_EXTENSION="tgz"
     ;;
 Linux*) 
     ONNXRUNTIME_PLATFORM="linux"
+	ONNXRUNTIME_ARCHIVE_EXTENSION="tgz"
     ;;
 MINGW*) 
     ONNXRUNTIME_PLATFORM="win"
+	ONNXRUNTIME_ARCHIVE_EXTENSION="zip"
     ;;
 *)
     echo "Unsupported platform: $platform"
@@ -72,14 +75,16 @@ esac
 
 # Set the correct ONNX Runtime download filename
 ONNXRUNTIME_FILE="onnxruntime-${ONNXRUNTIME_PLATFORM}-${ONNXRUNTIME_ARCH}"
+ONNXRUNTIME_DIR="${CURRENT_DIR}/onnxruntime-${ONNXRUNTIME_PLATFORM}-${ONNXRUNTIME_ARCH}"
 
 if [[ "$ONNXRUNTIME_GPU" -eq 1 ]]; then
     ONNXRUNTIME_FILE="${ONNXRUNTIME_FILE}-gpu"
+    ONNXRUNTIME_DIR="${ONNXRUNTIME_DIR}-gpu"
 fi
 
-ONNXRUNTIME_FILE="${ONNXRUNTIME_FILE}-${ONNXRUNTIME_VERSION}.tgz"
+ONNXRUNTIME_FILE="${ONNXRUNTIME_FILE}-${ONNXRUNTIME_VERSION}.${ONNXRUNTIME_ARCHIVE_EXTENSION}"
+ONNXRUNTIME_DIR="${ONNXRUNTIME_DIR}-${ONNXRUNTIME_VERSION}"
 ONNXRUNTIME_URL="https://github.com/microsoft/onnxruntime/releases/download/v${ONNXRUNTIME_VERSION}/${ONNXRUNTIME_FILE}"
-ONNXRUNTIME_DIR="${CURRENT_DIR}/onnxruntime-${ONNXRUNTIME_PLATFORM}-${ONNXRUNTIME_ARCH}-${ONNXRUNTIME_VERSION}"
 
 # Function to download and extract ONNX Runtime
 download_onnxruntime() {
@@ -91,10 +96,20 @@ download_onnxruntime() {
     fi
 
     echo "Extracting ONNX Runtime ..."
-    if ! tar -zxvf "${ONNXRUNTIME_FILE}" -C "$CURRENT_DIR"; then
-        echo "Error: Failed to extract ONNX Runtime."
-        exit 1
-    fi
+	if [[ "${ONNXRUNTIME_ARCHIVE_EXTENSION}" = "tgz" ]]; then
+		if ! tar -zxvf "${ONNXRUNTIME_FILE}" -C "$CURRENT_DIR"; then
+			echo "Error: Failed to extract ONNX Runtime."
+			exit 1
+		fi
+	elif [[ "${ONNXRUNTIME_ARCHIVE_EXTENSION}" = "zip" ]]; then
+		if ! unzip "${ONNXRUNTIME_FILE}" -d "$CURRENT_DIR"; then
+			echo "Error: Failed to extract ONNX Runtime."
+			exit 1
+		fi
+	else
+		echo "Error: Failed to extract ONNX Runtime."
+		exit 1
+	fi
 
     rm -f "${ONNXRUNTIME_FILE}"
 }


### PR DESCRIPTION
This PR fix issues met with build.sh on Windows platform.

- Now support tgz and zip archive format.
- Fix name of onnxruntime directory in GPU mode according to onnxruntime repository.