### PR TITLE
Add macro for yolo version choice

### DIFF
--- a/src/camera_inference.cpp
+++ b/src/camera_inference.cpp
@@ -56,13 +56,35 @@
 #include <opencv2/highgui/highgui.hpp>
 
 // Uncomment the version
-// #include "det/YOLO5.hpp"
-// #include "det/YOLO7.hpp"
-// #include "det/YOLO9.hpp"
-// #include "det/YOLO8.hpp"
-// #include "det/YOLO10.hpp"
-// #include "det/YOLO11.hpp" 
-#include "det/YOLO12.hpp" 
+//#define YOLO5
+//#define YOLO7
+//#define YOLO8
+//#define YOLO9
+//#define YOLO10
+//#define YOLO11
+#define YOLO12
+
+#ifdef YOLO5
+    #include "det/YOLO5.hpp"
+#endif
+#ifdef YOLO7
+    #include "det/YOLO7.hpp"
+#endif
+#ifdef YOLO8
+    #include "det/YOLO8.hpp"
+#endif
+#ifdef YOLO9
+    #include "det/YOLO9.hpp"
+#endif
+#ifdef YOLO10
+    #include "det/YOLO10.hpp"
+#endif
+#ifdef YOLO11
+    #include "det/YOLO11.hpp"
+#endif
+#ifdef YOLO12
+    #include "det/YOLO12.hpp"
+#endif
 
 
 // Include the bounded queue
@@ -74,14 +96,27 @@ int main()
     const bool isGPU = true;
     const std::string labelsPath = "../models/coco.names";
 
-    // std::string modelPath = "../models/yolo5-n6.onnx"; 
-    // const std::string modelPath = "../models/yolo7-tiny.onnx"; 
-    // std::string modelPath = "../models/yolo8n.onnx"; 
-    // std::string modelPath = "../models/yolo8n.onnx"; 
-    // const std::string modelPath = "../models/yolov9s.onnx"; 
-    // std::string modelPath = "../models/yolo10n_uint8.onnx"; 
-    // const std::string modelPath = "../models/yolo11n.onnx";
-    const std::string modelPath = "../models/yolo12n.onnx";
+    #ifdef YOLO5
+        std::string modelPath = "../models/yolo5-n6.onnx";
+    #endif
+    #ifdef YOLO7
+        const std::string modelPath = "../models/yolo7-tiny.onnx";
+    #endif
+    #ifdef YOLO8
+        std::string modelPath = "../models/yolo8n.onnx";
+    #endif
+    #ifdef YOLO9
+        const std::string modelPath = "../models/yolov9s.onnx";
+    #endif
+    #ifdef YOLO10
+        std::string modelPath = "../models/yolo10n_uint8.onnx";
+    #endif
+    #ifdef YOLO11
+        const std::string modelPath = "../models/yolo11n.onnx";
+    #endif
+    #ifdef YOLO12
+        const std::string modelPath = "../models/yolo12n.onnx";
+    #endif
 
 
 
@@ -90,8 +125,27 @@ int main()
     const std::string videoSource = "/dev/video0"; // your usb cam device
 
     // Initialize YOLO detector
-    // YOLO9Detector detector(modelPath, labelsPath, isGPU);
-    YOLO12Detector detector(modelPath, labelsPath, isGPU);
+    #ifdef YOLO5
+        YOLO5Detector detector(modelPath, labelsPath, isGPU);
+    #endif
+    #ifdef YOLO7
+        YOLO7Detector detector(modelPath, labelsPath, isGPU);
+    #endif
+    #ifdef YOLO8
+        YOLO8Detector detector(modelPath, labelsPath, isGPU);
+    #endif
+    #ifdef YOLO9
+        YOLO9Detector detector(modelPath, labelsPath, isGPU);
+    #endif
+    #ifdef YOLO10
+        YOLO10Detector detector(modelPath, labelsPath, isGPU);
+    #endif
+    #ifdef YOLO11
+        YOLO11Detector detector(modelPath, labelsPath, isGPU);
+    #endif
+    #ifdef YOLO12
+        YOLO12Detector detector(modelPath, labelsPath, isGPU);
+    #endif
 
 
     // Open video capture

--- a/src/image_inference.cpp
+++ b/src/image_inference.cpp
@@ -41,14 +41,36 @@
 #include <iostream>
 #include <string>
 
-// #include "det/YOLO5.hpp"  // Uncomment for YOLOv5
-// #include "det/YOLO7.hpp"  // Uncomment for YOLOv7
-// #include "det/YOLO8.hpp"  // Uncomment for YOLOv8
-// #include "det/YOLO9.hpp"  // Uncomment for YOLOv9
-// #include "det/YOLO10.hpp" // Uncomment for YOLOv10
-// #include "det/YOLO11.hpp" // Uncomment for YOLOv11
-#include "det/YOLO12.hpp" // Uncomment for YOLOv12
+// Uncomment the version
+//#define YOLO5 // Uncomment for YOLOv5
+//#define YOLO7 // Uncomment for YOLOv7
+//#define YOLO8 // Uncomment for YOLOv8
+//#define YOLO9 // Uncomment for YOLOv9
+//#define YOLO10 // Uncomment for YOLOv10
+//#define YOLO11 // Uncomment for YOLOv11
+#define YOLO12 // Uncomment for YOLOv12
 
+#ifdef YOLO5
+    #include "det/YOLO5.hpp"
+#endif
+#ifdef YOLO7
+    #include "det/YOLO7.hpp"
+#endif
+#ifdef YOLO8
+    #include "det/YOLO8.hpp"
+#endif
+#ifdef YOLO9
+    #include "det/YOLO9.hpp"
+#endif
+#ifdef YOLO10
+    #include "det/YOLO10.hpp"
+#endif
+#ifdef YOLO11
+    #include "det/YOLO11.hpp"
+#endif
+#ifdef YOLO12
+    #include "det/YOLO12.hpp"
+#endif
 
 
 int main(){
@@ -62,27 +84,53 @@ int main(){
     // const std::string imagePath = "../data/desk.jpg";        // Another alternate image
 
     // Model paths for different YOLO versions
-    // Uncomment the desired model path for testing
-    // const std::string modelPath = "../models/yolo5-n6.onnx";      // YOLOv5
-    // const std::string modelPath = "../models/yolo7-tiny.onnx";       // YOLOv7
-    // const std::string modelPath = "../models/yolo8n.onnx"; // YOLOv8
-    // const std::string modelPath = "../models/yolov9s.onnx"; // YOLOv9 
-    // const std::string modelPath = "../models/yolo10n.onnx"; // YOLOv10 
-    // const std::string modelPath = "../quantized_models/yolo10n_uint8.onnx"; // Quantized YOLOv10
-    // const std::string modelPath = "../models/yolo11n.onnx"; // YOLOv11 
-    const std::string modelPath = "../models/yolo12n.onnx"; // YOLOv12 
+    #ifdef YOLO5
+        std::string modelPath = "../models/yolo5-n6.onnx";
+    #endif
+    #ifdef YOLO7
+        const std::string modelPath = "../models/yolo7-tiny.onnx";
+    #endif
+    #ifdef YOLO8
+        std::string modelPath = "../models/yolo8n.onnx";
+    #endif
+    #ifdef YOLO9
+        const std::string modelPath = "../models/yolov9s.onnx";
+    #endif
+    #ifdef YOLO10
+        std::string modelPath = "../models/yolo10n_uint8.onnx";
+    #endif
+    #ifdef YOLO11
+        const std::string modelPath = "../models/yolo11n.onnx";
+    #endif
+    #ifdef YOLO12
+        const std::string modelPath = "../models/yolo12n.onnx";
+    #endif
 
 
 
     // Initialize the YOLO detector with the chosen model and labels
     bool isGPU = true; // Set to false for CPU processing
-    // YOLO7Detector detector(modelPath, labelsPath, isGPU);
-    // YOLO5Detector detector(modelPath, labelsPath, isGPU);  // Uncomment for YOLOv5
-    // YOLO8Detector detector(modelPath, labelsPath, isGPU);  // Uncomment for YOLOv8
-    // YOLO9Detector detector(modelPath, labelsPath, isGPU); // Uncomment for YOLOv9
-    // YOLO10Detector detector(modelPath, labelsPath, isGPU); // Uncomment for YOLOv10
-    // YOLO11Detector detector(modelPath, labelsPath, isGPU); // Uncomment for YOLOv11
-    YOLO12Detector detector(modelPath, labelsPath, isGPU); // Uncomment for YOLOv12
+    #ifdef YOLO5
+        YOLO5Detector detector(modelPath, labelsPath, isGPU);
+    #endif
+    #ifdef YOLO7
+        YOLO7Detector detector(modelPath, labelsPath, isGPU);
+    #endif
+    #ifdef YOLO8
+        YOLO8Detector detector(modelPath, labelsPath, isGPU);
+    #endif
+    #ifdef YOLO9
+        YOLO9Detector detector(modelPath, labelsPath, isGPU);
+    #endif
+    #ifdef YOLO10
+        YOLO10Detector detector(modelPath, labelsPath, isGPU);
+    #endif
+    #ifdef YOLO11
+        YOLO11Detector detector(modelPath, labelsPath, isGPU);
+    #endif
+    #ifdef YOLO12
+        YOLO12Detector detector(modelPath, labelsPath, isGPU);
+    #endif
 
 
     // Load an image

--- a/src/video_inference.cpp
+++ b/src/video_inference.cpp
@@ -47,14 +47,36 @@
 #include <atomic>
 #include <condition_variable>
 
-// #include "det/YOLO5.hpp"  // Uncomment for YOLOv5
-// #include "det/YOLO7.hpp"  // Uncomment for YOLOv7
-// #include "det/YOLO8.hpp"  // Uncomment for YOLOv8
-// #include "det/YOLO9.hpp"  // Uncomment for YOLOv9
-// #include "det/YOLO10.hpp" // Uncomment for YOLOv10
-// #include "det/YOLO11.hpp" // Uncomment for YOLOv11
-#include "det/YOLO12.hpp" // Uncomment for YOLOv12
+// Uncomment the version
+//#define YOLO5 // Uncomment for YOLOv5
+//#define YOLO7 // Uncomment for YOLOv7
+//#define YOLO8 // Uncomment for YOLOv8
+//#define YOLO9 // Uncomment for YOLOv9
+//#define YOLO10 // Uncomment for YOLOv10
+//#define YOLO11 // Uncomment for YOLOv11
+#define YOLO12 // Uncomment for YOLOv12
 
+#ifdef YOLO5
+    #include "det/YOLO5.hpp"
+#endif
+#ifdef YOLO7
+    #include "det/YOLO7.hpp"
+#endif
+#ifdef YOLO8
+    #include "det/YOLO8.hpp"
+#endif
+#ifdef YOLO9
+    #include "det/YOLO9.hpp"
+#endif
+#ifdef YOLO10
+    #include "det/YOLO10.hpp"
+#endif
+#ifdef YOLO11
+    #include "det/YOLO11.hpp"
+#endif
+#ifdef YOLO12
+    #include "det/YOLO12.hpp"
+#endif
 
 // Thread-safe queue implementation
 template <typename T>
@@ -102,18 +124,28 @@ int main()
     const std::string outputPath = "../data/SIG_experience_center_processed.mp4"; // Output video path
 
     // Model paths for different YOLO versions
-    // const std::string modelPath = "../models/yolov9s.onnx"; // YOLOv9
-    // const std::string modelPath = "../models/yolo11n.onnx"; // YOLOv11
-    const std::string modelPath = "../models/yolo12n.onnx"; // YOLOv12
-
+    #ifdef YOLO9
+        const std::string modelPath = "../models/yolov9s.onnx";
+    #endif
+    #ifdef YOLO11
+        const std::string modelPath = "../models/yolo11n.onnx";
+    #endif
+    #ifdef YOLO12
+        const std::string modelPath = "../models/yolo12n.onnx";
+    #endif
 
 
     // Initialize the YOLO detector
     bool isGPU = true; // Set to false for CPU processing
-    // YOLO9Detector detector(modelPath, labelsPath, isGPU); // YOLOv9
-    // YOLO11Detector detector(modelPath, labelsPath, isGPU); // YOLOv11
-    YOLO12Detector detector(modelPath, labelsPath, isGPU); // YOLOv12
-
+    #ifdef YOLO9
+        YOLO9Detector detector(modelPath, labelsPath, isGPU);
+    #endif
+    #ifdef YOLO11
+        YOLO11Detector detector(modelPath, labelsPath, isGPU);
+    #endif
+    #ifdef YOLO12
+        YOLO12Detector detector(modelPath, labelsPath, isGPU);
+    #endif
 
     // Open the video file
     cv::VideoCapture cap(videoPath);

--- a/src/video_inference.cpp
+++ b/src/video_inference.cpp
@@ -137,6 +137,15 @@ int main()
 
     // Initialize the YOLO detector
     bool isGPU = true; // Set to false for CPU processing
+    #ifdef YOLO5
+        YOLO5Detector detector(modelPath, labelsPath, isGPU);
+    #endif
+    #ifdef YOLO7
+        YOLO7Detector detector(modelPath, labelsPath, isGPU);
+    #endif
+    #ifdef YOLO8
+        YOLO8Detector detector(modelPath, labelsPath, isGPU);
+    #endif
     #ifdef YOLO9
         YOLO9Detector detector(modelPath, labelsPath, isGPU);
     #endif

--- a/src/video_inference.cpp
+++ b/src/video_inference.cpp
@@ -124,8 +124,20 @@ int main()
     const std::string outputPath = "../data/SIG_experience_center_processed.mp4"; // Output video path
 
     // Model paths for different YOLO versions
+    #ifdef YOLO5
+        std::string modelPath = "../models/yolo5-n6.onnx";
+    #endif
+    #ifdef YOLO7
+        const std::string modelPath = "../models/yolo7-tiny.onnx";
+    #endif
+    #ifdef YOLO8
+        std::string modelPath = "../models/yolo8n.onnx";
+    #endif
     #ifdef YOLO9
         const std::string modelPath = "../models/yolov9s.onnx";
+    #endif
+    #ifdef YOLO10
+        std::string modelPath = "../models/yolo10n_uint8.onnx";
     #endif
     #ifdef YOLO11
         const std::string modelPath = "../models/yolo11n.onnx";


### PR DESCRIPTION
This PR add C++ macro in projects **image_inference**, **video_inference** and **camera_inference** to make easier the Yolo version choice and avoid errors.

The developer just have to uncomment the `#define YOLO[version]` and don't have to uncomment the include, the model path and the call to `YOLO[version]Detector(...)`.