### PR TITLE
Adding starting CI container docker images, files and workflow

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -1,0 +1,9 @@
+# .github/actions/run-tests/action.yml
+name: "Run Tests"
+description: "Reusable test step"
+runs:
+  using: "composite"
+  steps:
+    - name: Run Tests
+      run: echo "Passed Tests!"
+      shell: bash

--- a/.github/docker-envs/Python.Dockerfile
+++ b/.github/docker-envs/Python.Dockerfile
@@ -1,0 +1,25 @@
+# Use NVIDIA's CUDA base image with Python
+FROM nvidia/cuda:12.2.0-base-ubuntu22.04
+
+# Avoid interactive prompts
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install Python and system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3.10 \
+    python3-pip \
+    python3-venv \
+    git \
+    wget \
+    curl \
+    unzip \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Upgrade pip
+RUN python3 -m pip install --upgrade pip \
+    && pip install --no-cache-dir ultralytics[export]
+
+
+# Set working directory
+WORKDIR /workspace

--- a/.github/docker-envs/UbuntuCPU.Dockerfile
+++ b/.github/docker-envs/UbuntuCPU.Dockerfile
@@ -1,0 +1,35 @@
+##nvidia/cuda for GPU support or ubuntu:22.04 for CPU
+FROM ubuntu:22.04
+
+# Set non-interactive mode for apt
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system dependencies
+# Install essential tools
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    cmake \
+    git \
+    wget \
+    curl \
+    unzip \
+    pkg-config \
+    ca-certificates \
+    # OpenCV (headless)
+    libopencv-dev \
+    # Media support
+    libavcodec-dev \
+    libavformat-dev \
+    libswscale-dev \
+    libv4l-dev \
+    libxvidcore-dev \
+    libx264-dev \
+    # Math libraries (choose one approach)
+    libopenblas-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+    
+
+
+# Set the working directory
+WORKDIR /workspace

--- a/.github/docker-envs/UbuntuGPU.Dockerfile
+++ b/.github/docker-envs/UbuntuGPU.Dockerfile
@@ -1,0 +1,37 @@
+##nvidia/cuda for GPU support or ubuntu:22.04 for CPU
+FROM nvidia/cuda:12.2.0-base-ubuntu22.04
+
+# Set non-interactive mode for apt
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system dependencies
+# Install essential tools
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    cmake \
+    git \
+    wget \
+    curl \
+    unzip \
+    pkg-config \
+    ca-certificates \
+    # OpenCV (headless)
+    libopencv-dev \
+    # Media support
+    libavcodec-dev \
+    libavformat-dev \
+    libswscale-dev \
+    libv4l-dev \
+    libxvidcore-dev \
+    libx264-dev \
+    # Math libraries (choose one approach)
+    libopenblas-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+    
+
+
+
+
+# Set the working directory
+WORKDIR /workspace

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,82 @@
+name: Main CI
+
+on:
+  push:
+    branches: ["main", "dev"]
+  pull_request:
+    branches: ["main", "dev"]
+  workflow_dispatch:   # <--- allows manual trigger
+
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  test:
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            image: ghcr.io/ahmedmsalah99/ubuntu_cpu:latest
+            build: ubuntu_cpu
+          - runner: ubuntu-latest
+            image: ghcr.io/ahmedmsalah99/ubuntu_gpu:latest
+            build: ubuntu_gpu
+
+    container:
+      image: ${{ matrix.image }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Fetch and unzip cpu models
+        if: matrix.build == 'ubuntu_cpu'
+        run: |
+          wget https://github.com/ahmedmsalah99/YOLOs-CPP/releases/download/v1/yolo_cpu_models.zip
+          unzip -o yolo_cpu_models.zip -d test_models
+          ls -R test_models
+          
+      - name: Fetch and unzip gpu models
+        if: matrix.build == 'ubuntu_gpu'
+        run: |
+          wget https://github.com/ahmedmsalah99/YOLOs-CPP/releases/download/v1/yolo_cpu_models.zip
+          unzip -o yolo_cpu_models.zip -d test_models
+          ls -R test_models
+
+      # CPU build
+      - name: Build CPU
+        if: matrix.build == 'ubuntu_cpu'
+        run: ./build.sh 1.20.1 0
+
+      # GPU build
+      - name: Build GPU
+        if: matrix.build == 'ubuntu_gpu'
+        run: ./build.sh 1.20.1 1
+
+      # Shared test step
+      - uses: ./.github/actions/run-tests
+
+  
+  # python-test:
+  #   runs-on: ubuntu-latest
+  #   if: github.event_name == 'workflow_dispatch'   # <--- run only on manual trigger
+  #   container:
+  #     image: ghcr.io/ahmedmsalah99/python:latest
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v4
+
+  #     - name: Fetch and unzip models
+  #       run: |
+  #         wget https://github.com/ahmedmsalah99/YOLOs-CPP/releases/download/v1/yolo_cpu_models.zip
+  #         unzip -o yolo_cpu_models.zip -d test_models
+  #         ls -R test_models
+
+  #     - name: Export ONNX
+  #       run: python models/export_onnx.py


### PR DESCRIPTION
Adding workflow for CI.
The workflow includes CPU and GPU execution when push or pull requests are done on main or dev branches.
Docker files for building the images are added too.
Tests are added as a separate action and different machines are added as a matrix.

Initial job for python container is added but commented. we still need to know what packages will be needed for the image so we can have the image. With ultralytics image's size is over 10 GB.