### PR TITLE
adding yolo-nas inference and post processing

### DIFF
--- a/include/det/YOLO.hpp
+++ b/include/det/YOLO.hpp
@@ -645,7 +645,6 @@ private:
     Ort::Session session{nullptr};                 // ONNX Runtime session for running inference
     bool isDynamicInputShape{};                    // Flag indicating if input shape is dynamic
     cv::Size inputImageShape;                      // Expected input image shape for the model
-
     // Vectors to hold allocated input and output node names
     std::vector<Ort::AllocatedStringPtr> inputNodeNameAllocatedStrings;
     std::vector<const char *> inputNames;
@@ -708,6 +707,14 @@ private:
                                       const std::vector<Ort::Value> &outputTensors,
                                       float confThreshold, float iouThreshold);
     
+    std::vector<Detection> postprocess_yolonas(
+                const cv::Size &originalImageSize,
+                const cv::Size &resizedImageShape,
+                const std::vector<Ort::Value> &outputTensors,
+                float confThreshold,
+                float iouThreshold
+                );
+    
 };
 
 // Implementation of YOLODetector constructor
@@ -759,9 +766,16 @@ YOLODetector::YOLODetector(const std::string &modelPath, const std::string &labe
     inputNames.push_back(inputNodeNameAllocatedStrings.back().get());
 
     // Allocate and store output node names
-    auto output_name = session.GetOutputNameAllocated(0, allocator);
-    outputNodeNameAllocatedStrings.push_back(std::move(output_name));
-    outputNames.push_back(outputNodeNameAllocatedStrings.back().get());
+    for (int layer=0; layer < this->session.GetOutputCount(); layer+=1)
+    {
+        #if ORT_API_VERSION < 13
+            outputNames.push_back(this->session.GetOutputName(layer, allocator));
+        #else
+            Ort::AllocatedStringPtr output_name_Ptr = this->session.GetOutputNameAllocated(layer, allocator);
+            outputNodeNameAllocatedStrings.push_back(std::move(output_name_Ptr));
+            outputNames.push_back(outputNodeNameAllocatedStrings.back().get());
+        #endif
+    }
 
     // Set the expected input image shape based on the model's input tensor
     if (inputTensorShapeVec.size() >= 4) {
@@ -827,7 +841,6 @@ std::vector<Detection> YOLODetector::postprocess(
     // Determine the number of features and detections
     const size_t num_features = outputShape[1];
     const size_t num_detections = outputShape[2];
-    // std::cout << "num_features " << num_features << " num_detections " << num_detections << " " << outputShape[3] << std::endl;
     // Early exit if no detections
     if (num_detections == 0) {
         return detections;
@@ -1015,6 +1028,109 @@ std::vector<Detection> YOLODetector::postprocess_yolo10(
 }
 
 // Postprocess function implementation
+std::vector<Detection> YOLODetector::postprocess_yolonas(
+    const cv::Size &originalImageSize,
+    const cv::Size &resizedImageShape,
+    const std::vector<Ort::Value> &outputTensors,
+    float confThreshold,
+    float iouThreshold
+) {
+    // Start timing the postprocessing step
+    ScopedTimer timer("Postprocessing");
+    std::vector<Detection> detections;
+    // Retrieve raw output data from the first output tensor
+    auto *rawOutput = outputTensors[0].GetTensorData<float>();
+    auto *rawOutput1 = outputTensors[1].GetTensorData<float>();
+    std::vector<int64_t> outputShape = outputTensors[0].GetTensorTypeAndShapeInfo().GetShape();
+    std::vector<int64_t> outputShape1 = outputTensors[1].GetTensorTypeAndShapeInfo().GetShape();
+
+    std::vector<Detection> detectionVector;
+
+    // Assume the second dimension represents the number of detections
+    int num_detections = outputShape[1];
+    DEBUG_PRINT("Number of detections before filtering: " << num_detections);
+    std::cout << "Number of detections before filtering: " << num_detections << std::endl;
+    if(num_detections == 0)
+        return detections;
+    DEBUG_PRINT("Number of detections before filtering: " << num_detections);
+    // Reserve memory for efficient appending
+    std::vector<BoundingBox> boxes;
+    boxes.reserve(num_detections);
+    std::vector<float> confs;
+    confs.reserve(num_detections);
+    std::vector<int> classIds;
+    classIds.reserve(num_detections);
+    std::vector<BoundingBox> nms_boxes;
+    nms_boxes.reserve(num_detections);
+
+    // Iterate through each detection and filter based on confidence threshold
+    for (int i = 0; i < num_detections; i++) {
+        float x1 = rawOutput[i * 4 + 0];
+        float y1 = rawOutput[i * 4 + 1];
+        float x2 = rawOutput[i * 4 + 2];
+        float y2 = rawOutput[i * 4 + 3];
+        int classId = -1;
+        float confidence = -FLT_MAX;
+        for (int c = 0; c < outputShape1[2]; ++c) {
+            const float score = rawOutput1[i * outputShape1[2] + c];
+            if (score > confidence) {
+                confidence = score;
+                classId = c;
+            }
+        }
+
+        // Proceed only if confidence exceeds threshold
+        if (confidence > confThreshold) {
+            // Scale to original image size
+            BoundingBox scaledBox = utils::ImagePreprocessingUtils::scaleCoords(
+                resizedImageShape,
+                BoundingBox(x1, y1, x2-x1, y2-y1),
+                originalImageSize,
+                true
+            );
+
+            // Round coordinates for integer pixel positions
+            BoundingBox roundedBox;
+            roundedBox.x = std::round(scaledBox.x);
+            roundedBox.y = std::round(scaledBox.y);
+            roundedBox.width = std::round(scaledBox.width);
+            roundedBox.height = std::round(scaledBox.height);
+
+            // Adjust NMS box coordinates to prevent overlap between classes
+            BoundingBox nmsBox = roundedBox;
+            nmsBox.x += classId * 7680; // Arbitrary offset to differentiate classes
+            nmsBox.y += classId * 7680;
+
+            // Add to respective containers
+            nms_boxes.emplace_back(nmsBox);
+            boxes.emplace_back(roundedBox);
+            confs.emplace_back(confidence);
+            classIds.emplace_back(classId);
+        }
+    }
+
+    // Apply Non-Maximum Suppression (NMS) to eliminate redundant detections
+    std::vector<int> indices;
+    utils::NMSBoxes(nms_boxes, confs, confThreshold, iouThreshold, indices);
+
+    // Collect filtered detections into the result vector
+    detections.reserve(indices.size());
+    for (const int idx : indices) {
+        detections.emplace_back(Detection{
+            boxes[idx],       // Bounding box
+            confs[idx],       // Confidence score
+            classIds[idx]     // Class ID
+        });
+    }
+
+    DEBUG_PRINT("Postprocessing completed") // Debug log for completion
+
+    return detections;
+
+}
+
+
+// Postprocess function implementation
 std::vector<Detection> YOLODetector::postprocess_yolo7(
     const cv::Size &originalImageSize,
     const cv::Size &resizedImageShape,
@@ -1138,7 +1254,7 @@ std::vector<Detection> YOLODetector::detect(const cv::Mat& image, float confThre
         inputTensorShape.data(),
         inputTensorShape.size()
     );
-
+    std::cout << "data " << outputNames.data()[0] << std::endl;
     // Run the inference session with the input tensor and retrieve output tensors
     std::vector<Ort::Value> outputTensors = session.Run(
         Ort::RunOptions{nullptr},
@@ -1155,13 +1271,16 @@ std::vector<Detection> YOLODetector::detect(const cv::Mat& image, float confThre
     // Postprocess the output tensors to obtain detections
     std::vector<Detection> detections;
     const std::vector<int64_t> outputShape = outputTensors[0].GetTensorTypeAndShapeInfo().GetShape();
-    // std::cout << "out shape 0 "<< outputShape[0] << " 1 " << outputShape[1] << " 2 " << outputShape[2] << std::endl;
     if(outputShape[2] == 6){
         // std::cout << "yolo 10 detected" << std::endl;
         detections = postprocess_yolo10(image.size(), resizedImageShape, outputTensors, confThreshold, iouThreshold);
     }else if(outputShape[1] == 7){
         // std::cout << "yolo 7 detected" << std::endl;
         detections = postprocess_yolo7(image.size(), resizedImageShape, outputTensors, confThreshold, iouThreshold);
+    }
+    else if(outputShape[2] == 4){
+        // std::cout << "yolo nas detected" << std::endl;
+        detections = postprocess_yolonas(image.size(), resizedImageShape, outputTensors, confThreshold, iouThreshold);
     }
     else{
         // std::cout << "yolo not 10 detected" << std::endl;

--- a/models/export_onnx.py
+++ b/models/export_onnx.py
@@ -1,4 +1,5 @@
 from ultralytics import YOLO
+from ultralytics import NAS
 
 # Load the YOLOv12n model
 
@@ -8,9 +9,11 @@ from ultralytics import YOLO
 # model = YOLO("yolov8n.pt")
 # model = YOLO("yolov9t.pt")
 # model = YOLO("yolov10n.pt")
-model = YOLO("yolo11n.pt")
+# model = YOLO("yolo11n.pt")
 # model = YOLO("yolo12n.pt")
+model = NAS("yolo_nas_s.pt")
 
 
 # Export the model to ONNX format
 model.export(format="onnx")
+


### PR DESCRIPTION
adding yolo-nas inference and post processing method. 
Added code for exporting yolo nas as well inside export_onnx.py.
Added a more general way for determining output names when constructing the detector. 

This pull request is because of the hardness of using onnx with YOLO-nas. 
I checked https://github.com/Hyuto/yolo-nas-onnx/tree/master 
and https://github.com/jason-li-831202/YOLO-NAS-onnxruntime/tree/master

Which are popular but none worked easily (errors and unexplained issues).
So, I decided to add it on our YOLO support. 