### PR TITLE
adding batch support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,17 +25,23 @@ add_executable(video_inference
 add_executable(class_image_inference
                src/class_image_inference.cpp)
 
+# Add executable for batch image inference
+add_executable(batch_image_inference
+               src/batch_image_inference.cpp)
+
 # Set include directories for all executables
 target_include_directories(image_inference PRIVATE "${ONNXRUNTIME_DIR}/include")
 target_include_directories(camera_inference PRIVATE "${ONNXRUNTIME_DIR}/include")
 target_include_directories(video_inference PRIVATE "${ONNXRUNTIME_DIR}/include")
 target_include_directories(class_image_inference PRIVATE "${ONNXRUNTIME_DIR}/include")
+target_include_directories(batch_image_inference PRIVATE "${ONNXRUNTIME_DIR}/include")
 
 # Link libraries for all executables
 target_link_libraries(image_inference ${OpenCV_LIBS})
 target_link_libraries(camera_inference ${OpenCV_LIBS})
 target_link_libraries(video_inference ${OpenCV_LIBS})
 target_link_libraries(class_image_inference ${OpenCV_LIBS})
+target_link_libraries(batch_image_inference ${OpenCV_LIBS})
 
 if(UNIX)
     message(STATUS "We are building on Linux!")
@@ -44,6 +50,7 @@ if(UNIX)
     target_link_libraries(camera_inference "${ONNXRUNTIME_DIR}/lib/libonnxruntime.so")
     target_link_libraries(video_inference "${ONNXRUNTIME_DIR}/lib/libonnxruntime.so")
     target_link_libraries(class_image_inference "${ONNXRUNTIME_DIR}/lib/libonnxruntime.so")
+    target_link_libraries(batch_image_inference "${ONNXRUNTIME_DIR}/lib/libonnxruntime.so")
 endif(UNIX)
 
 if(APPLE)
@@ -53,6 +60,7 @@ if(APPLE)
     target_link_libraries(camera_inference "${ONNXRUNTIME_DIR}/lib/libonnxruntime.dylib")
     target_link_libraries(video_inference "${ONNXRUNTIME_DIR}/lib/libonnxruntime.dylib")
     target_link_libraries(class_image_inference "${ONNXRUNTIME_DIR}/lib/libonnxruntime.dylib")
+    target_link_libraries(batch_image_inference "${ONNXRUNTIME_DIR}/lib/libonnxruntime.dylib")
 endif(APPLE)
 
 if(WIN32)
@@ -62,4 +70,5 @@ if(WIN32)
     target_link_libraries(camera_inference "${ONNXRUNTIME_DIR}/lib/onnxruntime.lib")
     target_link_libraries(video_inference "${ONNXRUNTIME_DIR}/lib/onnxruntime.lib")
     target_link_libraries(class_image_inference "${ONNXRUNTIME_DIR}/lib/onnxruntime.lib")
+    target_link_libraries(batch_image_inference "${ONNXRUNTIME_DIR}/lib/libonnxruntime.lib")
 endif(WIN32)

--- a/include/det/YOLO.hpp
+++ b/include/det/YOLO.hpp
@@ -693,7 +693,7 @@ private:
     std::vector<cv::Size> batch_preprocess(const std::vector<cv::Mat> &images, float *&blob, std::vector<int64_t> &inputTensorShape);
     
     /**
-     * @brief Postprocesses the model output to extract detections for a single image.
+     * @brief Postprocesses the model output to extract detections.
      * 
      * @param originalImageSize Size of the original input image.
      * @param resizedImageShape Size of the image after preprocessing.
@@ -707,7 +707,7 @@ private:
                                       const std::vector<Ort::Value> &outputTensors,int img_idx,
                                       float confThreshold, float iouThreshold);
     /**
-     * @brief Postprocesses the model output to extract detections for a single image.
+     * @brief Postprocesses the model output to extract detections.
      * 
      * @param originalImageSize Size of the original input image.
      * @param resizedImageShape Size of the image after preprocessing.
@@ -721,7 +721,7 @@ private:
                                       const std::vector<Ort::Value> &outputTensors,int img_idx,
                                       float confThreshold, float iouThreshold);
     /**
-     * @brief Postprocesses the model output to extract detections for a single image.
+     * @brief Postprocesses the model output to extract detections.
      * 
      * @param originalImageSize Size of the original input image.
      * @param resizedImageShape Size of the image after preprocessing.
@@ -735,7 +735,7 @@ private:
                                       const std::vector<Ort::Value> &outputTensors,int img_idx,
                                       float confThreshold, float iouThreshold);
     /**
-     * @brief Postprocesses the model output to extract detections for a single image.
+     * @brief Postprocesses the model output to extract detections.
      * 
      * @param originalImageSize Size of the original input image.
      * @param resizedImageShape Size of the image after preprocessing.

--- a/include/det/YOLO.hpp
+++ b/include/det/YOLO.hpp
@@ -154,7 +154,6 @@ namespace utils
             {
                 ratio = std::min(ratio, 1.0f);
             }
-
             // Calculate new dimensions after scaling
             int newUnpadW = static_cast<int>(std::round(image.cols * ratio));
             int newUnpadH = static_cast<int>(std::round(image.rows * ratio));
@@ -163,13 +162,7 @@ namespace utils
             int dw = newShape.width - newUnpadW;
             int dh = newShape.height - newUnpadH;
 
-            if (auto_)
-            {
-                // Ensure padding is a multiple of stride for model compatibility
-                dw = (dw % stride) / 2;
-                dh = (dh % stride) / 2;
-            }
-            else if (scaleFill)
+            if (scaleFill)
             {
                 // Scale to fill without maintaining aspect ratio
                 newUnpadW = newShape.width;
@@ -187,7 +180,6 @@ namespace utils
                 int padRight = dw - padLeft;
                 int padTop = dh / 2;
                 int padBottom = dh - padTop;
-
                 // Resize the image if the new dimensions differ
                 if (image.cols != newUnpadW || image.rows != newUnpadH)
                 {
@@ -203,7 +195,6 @@ namespace utils
                 cv::copyMakeBorder(outImage, outImage, padTop, padBottom, padLeft, padRight, cv::BORDER_CONSTANT, color);
                 return; // Exit early since padding is already applied
             }
-
             // Resize the image if the new dimensions differ
             if (image.cols != newUnpadW || image.rows != newUnpadH)
             {
@@ -622,6 +613,17 @@ public:
      * @return std::vector<Detection> Vector of detections.
      */
     std::vector<Detection> detect(const cv::Mat &image, float confThreshold = 0.4f, float iouThreshold = 0.45f);
+
+    /**
+     * @brief Runs detection on a batch of images.
+     * 
+     * @param images Vector of input images for detection.
+     * @param confThreshold Confidence threshold to filter detections (default is 0.4).
+     * @param iouThreshold IoU threshold for Non-Maximum Suppression (default is 0.45).
+     * @return std::vector<std::vector<Detection>> Vector of detections for each image.
+     */
+    std::vector<std::vector<Detection>> detect(const std::vector<cv::Mat> &images, float confThreshold = 0.4f, float iouThreshold = 0.45f);
+
     
     /**
      * @brief Draws bounding boxes on the image based on detections.
@@ -656,6 +658,7 @@ private:
     Ort::SessionOptions sessionOptions{nullptr};   // Session options for ONNX Runtime
     Ort::Session session{nullptr};                 // ONNX Runtime session for running inference
     bool isDynamicInputShape{};                    // Flag indicating if input shape is dynamic
+    bool isDynamicBatchSize{};                     // Flag indicating if batch size is dynamic
     cv::Size inputImageShape;                      // Expected input image shape for the model
     // Vectors to hold allocated input and output node names
     std::vector<Ort::AllocatedStringPtr> inputNodeNameAllocatedStrings;
@@ -678,52 +681,66 @@ private:
      * @return cv::Mat Resized image after preprocessing.
      */
     cv::Mat preprocess(const cv::Mat &image, float *&blob, std::vector<int64_t> &inputTensorShape);
+
+    /**
+     * @brief Preprocesses a batch of images for model inference.
+     * 
+     * @param images Vector of input images.
+     * @param blob Reference to pointer where preprocessed batch data will be stored.
+     * @param inputTensorShape Reference to vector representing input tensor shape.
+     * @return std::vector<cv::Size> Vector of resized image shapes.
+     */
+    std::vector<cv::Size> batch_preprocess(const std::vector<cv::Mat> &images, float *&blob, std::vector<int64_t> &inputTensorShape);
     
     /**
-     * @brief Postprocesses the model output to extract detections.
+     * @brief Postprocesses the model output to extract detections for a single image.
      * 
      * @param originalImageSize Size of the original input image.
      * @param resizedImageShape Size of the image after preprocessing.
      * @param outputTensors Vector of output tensors from the model.
+     * @param img_idx Index of the image we need to process its output
      * @param confThreshold Confidence threshold to filter detections.
      * @param iouThreshold IoU threshold for Non-Maximum Suppression.
      * @return std::vector<Detection> Vector of detections.
      */
     std::vector<Detection> postprocess(const cv::Size &originalImageSize, const cv::Size &resizedImageShape,
-                                      const std::vector<Ort::Value> &outputTensors,
+                                      const std::vector<Ort::Value> &outputTensors,int img_idx,
                                       float confThreshold, float iouThreshold);
     /**
-     * @brief Postprocesses the model output to extract detections.
+     * @brief Postprocesses the model output to extract detections for a single image.
      * 
      * @param originalImageSize Size of the original input image.
      * @param resizedImageShape Size of the image after preprocessing.
      * @param outputTensors Vector of output tensors from the model.
+     * @param img_idx Index of the image we need to process its output
      * @param confThreshold Confidence threshold to filter detections.
      * @param iouThreshold IoU threshold for Non-Maximum Suppression.
      * @return std::vector<Detection> Vector of detections.
      */
     std::vector<Detection> postprocess_yolo10(const cv::Size &originalImageSize, const cv::Size &resizedImageShape,
-                                      const std::vector<Ort::Value> &outputTensors,
+                                      const std::vector<Ort::Value> &outputTensors,int img_idx,
                                       float confThreshold, float iouThreshold);
     /**
-     * @brief Postprocesses the model output to extract detections.
+     * @brief Postprocesses the model output to extract detections for a single image.
      * 
      * @param originalImageSize Size of the original input image.
      * @param resizedImageShape Size of the image after preprocessing.
      * @param outputTensors Vector of output tensors from the model.
+     * @param img_idx Index of the image we need to process its output
      * @param confThreshold Confidence threshold to filter detections.
      * @param iouThreshold IoU threshold for Non-Maximum Suppression.
      * @return std::vector<Detection> Vector of detections.
      */
     std::vector<Detection> postprocess_yolo7(const cv::Size &originalImageSize, const cv::Size &resizedImageShape,
-                                      const std::vector<Ort::Value> &outputTensors,
+                                      const std::vector<Ort::Value> &outputTensors,int img_idx,
                                       float confThreshold, float iouThreshold);
     /**
-     * @brief Postprocesses the model output to extract detections.
+     * @brief Postprocesses the model output to extract detections for a single image.
      * 
      * @param originalImageSize Size of the original input image.
      * @param resizedImageShape Size of the image after preprocessing.
      * @param outputTensors Vector of output tensors from the model.
+     * @param img_idx Index of the image we need to process its output
      * @param confThreshold Confidence threshold to filter detections.
      * @param iouThreshold IoU threshold for Non-Maximum Suppression.
      * @return std::vector<Detection> Vector of detections.
@@ -731,7 +748,7 @@ private:
     std::vector<Detection> postprocess_yolonas(
                 const cv::Size &originalImageSize,
                 const cv::Size &resizedImageShape,
-                const std::vector<Ort::Value> &outputTensors,
+                const std::vector<Ort::Value> &outputTensors,int img_idx,
                 float confThreshold,
                 float iouThreshold
                 );
@@ -779,7 +796,8 @@ YOLODetector::YOLODetector(const std::string &modelPath, const std::string &labe
     // Retrieve input tensor shape information
     Ort::TypeInfo inputTypeInfo = session.GetInputTypeInfo(0);
     std::vector<int64_t> inputTensorShapeVec = inputTypeInfo.GetTensorTypeAndShapeInfo().GetShape();
-    isDynamicInputShape = (inputTensorShapeVec.size() >= 4) && (inputTensorShapeVec[2] == -1 && inputTensorShapeVec[3] == -1); // Check for dynamic dimensions
+    isDynamicInputShape = (inputTensorShapeVec.size() >= 4) && (inputTensorShapeVec[2] == -1 || inputTensorShapeVec[3] == -1); // Check for dynamic height/width
+    isDynamicBatchSize = (inputTensorShapeVec.size() >= 4) && (inputTensorShapeVec[0] == -1); // Check for dynamic batch size
 
     // Allocate and store input node names
     auto input_name = session.GetInputNameAllocated(0, allocator);
@@ -801,6 +819,9 @@ YOLODetector::YOLODetector(const std::string &modelPath, const std::string &labe
     // Set the expected input image shape based on the model's input tensor
     if (inputTensorShapeVec.size() >= 4) {
         inputImageShape = cv::Size(static_cast<int>(inputTensorShapeVec[3]), static_cast<int>(inputTensorShapeVec[2]));
+        int height = (inputTensorShapeVec[2] == -1) ? 640 : static_cast<int>(inputTensorShapeVec[2]);
+        int width = (inputTensorShapeVec[3] == -1) ? 640 : static_cast<int>(inputTensorShapeVec[3]);
+        inputImageShape = cv::Size(width, height);
     } else {
         throw std::runtime_error("Invalid input tensor shape.");
     }
@@ -846,14 +867,60 @@ cv::Mat YOLODetector::preprocess(const cv::Mat &image, float *&blob, std::vector
 #endif
     return resizedImage;
 }
+
+// Batch preprocess function implementation
+std::vector<cv::Size> YOLODetector::batch_preprocess(const std::vector<cv::Mat> &images, float *&blob, std::vector<int64_t> &inputTensorShape) {
+#ifdef TIMING_MODE
+    ScopedTimer timer("batch preprocessing");
+#endif
+    size_t batchSize = images.size();
+    if (batchSize == 0) {
+        blob = nullptr;
+        return {};
+    }
+
+    // Resize all images to the same size (inputImageShape) with letterbox
+    std::vector<cv::Mat> resizedImages(batchSize);
+    std::vector<cv::Size> resizedShapes(batchSize);
+    for (size_t i = 0; i < batchSize; ++i) {
+        utils::ImagePreprocessingUtils::letterBox(images[i], resizedImages[i], inputImageShape, cv::Scalar(114, 114, 114), isDynamicInputShape, false, true, 32);
+        resizedShapes[i] = resizedImages[i].size();
+    }
+    
+    // Update input tensor shape for batch size and image dimensions
+    inputTensorShape[0] = static_cast<int64_t>(batchSize);
+    inputTensorShape[2] = resizedImages[0].rows;
+    inputTensorShape[3] = resizedImages[0].cols;
+
+    // Allocate memory for the batch blob: batch * channels * height * width
+    size_t totalSize = batchSize * 3 * resizedImages[0].rows * resizedImages[0].cols;
+    blob = new float[totalSize];
+
+    // Convert each image to float and normalize, then copy to blob in CHW format
+    for (size_t b = 0; b < batchSize; ++b) {
+        cv::Mat floatImage;
+        resizedImages[b].convertTo(floatImage, CV_32FC3, 1 / 255.0f);
+
+        std::vector<cv::Mat> chw(3);
+        for (int c = 0; c < 3; ++c) {
+            chw[c] = cv::Mat(resizedImages[b].rows, resizedImages[b].cols, CV_32FC1, blob + b * 3 * resizedImages[b].rows * resizedImages[b].cols + c * resizedImages[b].rows * resizedImages[b].cols);
+        }
+        cv::split(floatImage, chw);
+    }
+#ifdef DEBUG_MODE
+    DEBUG_PRINT("Batch preprocessing completed");
+#endif
+    return resizedShapes;
+}
 // Postprocess function to convert raw model output into detections
 std::vector<Detection> YOLODetector::postprocess(
     const cv::Size &originalImageSize,
     const cv::Size &resizedImageShape,
     const std::vector<Ort::Value> &outputTensors,
+    int img_idx,
     float confThreshold,
     float iouThreshold
-) {
+    ) {
 #ifdef TIMING_MODE
     ScopedTimer timer("postprocessing"); // Measure postprocessing time
 #endif
@@ -861,21 +928,20 @@ std::vector<Detection> YOLODetector::postprocess(
     const float* rawOutput = outputTensors[0].GetTensorData<float>(); // Extract raw output data from the first output tensor
     const std::vector<int64_t> outputShape = outputTensors[0].GetTensorTypeAndShapeInfo().GetShape();
 
+    int det_offset = img_idx*outputShape[1]*outputShape[2];
     // Determine the number of features and detections
-    const size_t num_features = outputShape[1];
-    const size_t num_detections = outputShape[2];
+    const size_t num_features = outputShape[2] > outputShape[1] ? outputShape[1] : outputShape[2];
+    const size_t num_detections = outputShape[2] > outputShape[1] ? outputShape[2] : outputShape[1];
     // Early exit if no detections
     if (num_detections == 0) {
         return detections;
     }
-
     // Calculate number of classes based on output shape
     const int numClasses = static_cast<int>(num_features) - 4;
     if (numClasses <= 0) {
         // Invalid number of classes
         return detections;
     }
-
     // Reserve memory for efficient appending
     std::vector<BoundingBox> boxes;
     boxes.reserve(num_detections);
@@ -885,28 +951,25 @@ std::vector<Detection> YOLODetector::postprocess(
     classIds.reserve(num_detections);
     std::vector<BoundingBox> nms_boxes;
     nms_boxes.reserve(num_detections);
-
     // Constants for indexing
     const float* ptr = rawOutput;
 
     for (size_t d = 0; d < num_detections; ++d) {
         // Extract bounding box coordinates (center x, center y, width, height)
-        float centerX = ptr[0 * num_detections + d];
-        float centerY = ptr[1 * num_detections + d];
-        float width = ptr[2 * num_detections + d];
-        float height = ptr[3 * num_detections + d];
-
+        float centerX = ptr[det_offset + 0 * num_detections + d];
+        float centerY = ptr[det_offset + 1 * num_detections + d];
+        float width = ptr[det_offset + 2 * num_detections + d];
+        float height = ptr[det_offset + 3 * num_detections + d];
         // Find class with the highest confidence score
         int classId = -1;
         float maxScore = -FLT_MAX;
         for (int c = 0; c < numClasses; ++c) {
-            const float score = ptr[d + (4 + c) * num_detections];
+            const float score = ptr[det_offset + d + (4 + c) * num_detections];
             if (score > maxScore) {
                 maxScore = score;
                 classId = c;
             }
         }
-
         // Proceed only if confidence exceeds threshold
         if (maxScore > confThreshold) {
             // Convert center coordinates to top-left (x1, y1)
@@ -940,7 +1003,6 @@ std::vector<Detection> YOLODetector::postprocess(
             classIds.emplace_back(classId);
         }
     }
-
     // Apply Non-Maximum Suppression (NMS) to eliminate redundant detections
     std::vector<int> indices;
     utils::NMSBoxes(nms_boxes, confs, confThreshold, iouThreshold, indices);
@@ -964,6 +1026,7 @@ std::vector<Detection> YOLODetector::postprocess_yolo10(
     const cv::Size &originalImageSize,
     const cv::Size &resizedImageShape,
     const std::vector<Ort::Value> &outputTensors,
+    int img_idx,
     float confThreshold,
     float iouThreshold
 ) {
@@ -978,7 +1041,7 @@ std::vector<Detection> YOLODetector::postprocess_yolo10(
     size_t count = outputTensors[0].GetTensorTypeAndShapeInfo().GetElementCount();
 
     std::vector<Detection> detectionVector;
-
+    int det_offset = img_idx*outputShape[1]*outputShape[2];
     // Assume the second dimension represents the number of detections
     int num_detections = outputShape[1];
     if(num_detections == 0)
@@ -997,12 +1060,12 @@ std::vector<Detection> YOLODetector::postprocess_yolo10(
     nms_boxes.reserve(num_detections);
     // Iterate through each detection and filter based on confidence threshold
     for (int i = 0; i < num_detections; i++) {
-        float x1 = rawOutput[i * 6 + 0];
-        float y1 = rawOutput[i * 6 + 1];
-        float x2 = rawOutput[i * 6 + 2];
-        float y2 = rawOutput[i * 6 + 3];
-        float confidence = rawOutput[i * 6 + 4];
-        int classId = static_cast<int>(rawOutput[i * 6 + 5]);
+        float x1 = rawOutput[det_offset + i * 6 + 0];
+        float y1 = rawOutput[det_offset + i * 6 + 1];
+        float x2 = rawOutput[det_offset + i * 6 + 2];
+        float y2 = rawOutput[det_offset + i * 6 + 3];
+        float confidence = rawOutput[det_offset + i * 6 + 4];
+        int classId = static_cast<int>(rawOutput[det_offset + i * 6 + 5]);
 
         // Proceed only if confidence exceeds threshold
         if (confidence > confThreshold) {
@@ -1059,6 +1122,7 @@ std::vector<Detection> YOLODetector::postprocess_yolonas(
     const cv::Size &originalImageSize,
     const cv::Size &resizedImageShape,
     const std::vector<Ort::Value> &outputTensors,
+    int img_idx,
     float confThreshold,
     float iouThreshold
 ) {
@@ -1074,7 +1138,8 @@ std::vector<Detection> YOLODetector::postprocess_yolonas(
     std::vector<int64_t> outputShape1 = outputTensors[1].GetTensorTypeAndShapeInfo().GetShape();
 
     std::vector<Detection> detectionVector;
-
+    int det_offset = img_idx*outputShape[1]*outputShape[2];
+    int det_offset1 = img_idx*outputShape1[1]*outputShape1[2];
     // Assume the second dimension represents the number of detections
     int num_detections = outputShape[1];
 #ifdef DEBUG_MODE
@@ -1098,14 +1163,14 @@ std::vector<Detection> YOLODetector::postprocess_yolonas(
 
     // Iterate through each detection and filter based on confidence threshold
     for (int i = 0; i < num_detections; i++) {
-        float x1 = rawOutput[i * 4 + 0];
-        float y1 = rawOutput[i * 4 + 1];
-        float x2 = rawOutput[i * 4 + 2];
-        float y2 = rawOutput[i * 4 + 3];
+        float x1 = rawOutput[det_offset + i * 4 + 0];
+        float y1 = rawOutput[det_offset + i * 4 + 1];
+        float x2 = rawOutput[det_offset + i * 4 + 2];
+        float y2 = rawOutput[det_offset + i * 4 + 3];
         int classId = -1;
         float confidence = -FLT_MAX;
         for (int c = 0; c < outputShape1[2]; ++c) {
-            const float score = rawOutput1[i * outputShape1[2] + c];
+            const float score = rawOutput1[det_offset1 + i * outputShape1[2] + c];
             if (score > confidence) {
                 confidence = score;
                 classId = c;
@@ -1168,9 +1233,10 @@ std::vector<Detection> YOLODetector::postprocess_yolo7(
     const cv::Size &originalImageSize,
     const cv::Size &resizedImageShape,
     const std::vector<Ort::Value> &outputTensors,
+    int img_idx,
     float confThreshold,
     float iouThreshold
-) {
+    ) {
     // Start timing the postprocessing step
 #ifdef TIMING_MODE
     ScopedTimer timer("Postprocessing");
@@ -1263,6 +1329,7 @@ std::vector<Detection> YOLODetector::postprocess_yolo7(
 
 }
 
+
 // Detect function implementation
 std::vector<Detection> YOLODetector::detect(const cv::Mat& image, float confThreshold, float iouThreshold) {
 #ifdef TIMING_MODE
@@ -1276,7 +1343,7 @@ std::vector<Detection> YOLODetector::detect(const cv::Mat& image, float confThre
     cv::Mat preprocessedImage = preprocess(image, blobPtr, inputTensorShape);
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
                             std::chrono::high_resolution_clock::now() - start);
-    
+
     // Compute the total number of elements in the input tensor
     size_t inputTensorSize = utils::MathUtils::vectorProduct(inputTensorShape);
 
@@ -1322,24 +1389,115 @@ std::vector<Detection> YOLODetector::detect(const cv::Mat& image, float confThre
     start = std::chrono::high_resolution_clock::now();
     std::vector<Detection> detections;
     const std::vector<int64_t> outputShape = outputTensors[0].GetTensorTypeAndShapeInfo().GetShape();
+    std::cout << "outputShape " << outputShape[0] << " " << outputShape[1] << " " << outputShape[2] << " " << outputShape[3] << std::endl;
     if(outputShape[2] == 6){
         // std::cout << "yolo 10 detected" << std::endl;
-        detections = postprocess_yolo10(image.size(), resizedImageShape, outputTensors, confThreshold, iouThreshold);
-    }else if(outputShape[1] == 7){
-        // std::cout << "yolo 7 detected" << std::endl;
-        detections = postprocess_yolo7(image.size(), resizedImageShape, outputTensors, confThreshold, iouThreshold);
+        detections = postprocess_yolo10(image.size(), resizedImageShape, outputTensors,0, confThreshold, iouThreshold);
+    }
+    else if(outputShape[1] == 7){
+        std::cout << "yolo 7 detected" << std::endl;
+        detections = postprocess_yolo7(image.size(), resizedImageShape, outputTensors,0, confThreshold, iouThreshold);
     }
     else if(outputShape[2] == 4){
         // std::cout << "yolo nas detected" << std::endl;
-        detections = postprocess_yolonas(image.size(), resizedImageShape, outputTensors, confThreshold, iouThreshold);
+        detections = postprocess_yolonas(image.size(), resizedImageShape, outputTensors,0, confThreshold, iouThreshold);
     }
     else{
-        // std::cout << "yolo not 10 detected" << std::endl;
-        detections = postprocess(image.size(), resizedImageShape, outputTensors, confThreshold, iouThreshold);
+        std::cout << "yolo not 10 detected" << std::endl;
+        detections = postprocess(image.size(), resizedImageShape, outputTensors,0, confThreshold, iouThreshold);
     }
-    
+
     duration = std::chrono::duration_cast<std::chrono::milliseconds>(
                             std::chrono::high_resolution_clock::now() - start);
     std::cout << "postporcessing completed in: " << duration.count() << " ms" << std::endl;
     return detections; // Return the vector of detections
+}
+
+// Batch detect function implementation
+std::vector<std::vector<Detection>> YOLODetector::detect(const std::vector<cv::Mat>& images, float confThreshold, float iouThreshold) {
+#ifdef TIMING_MODE
+    ScopedTimer timer("Overall batch detection");
+#endif
+    if (images.empty()) {
+        return {};
+    }
+
+    float* blobPtr = nullptr; // Pointer to hold preprocessed batch data
+    // Define the shape of the input tensor (batch size, channels, height, width)
+    std::vector<int64_t> inputTensorShape = {static_cast<int64_t>(images.size()), 3, inputImageShape.height, inputImageShape.width};
+    auto start = std::chrono::high_resolution_clock::now();
+    // Batch preprocess the images and obtain a pointer to the blob
+    std::vector<cv::Size> resizedShapes = batch_preprocess(images, blobPtr, inputTensorShape);
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+                            std::chrono::high_resolution_clock::now() - start);
+
+    // Compute the total number of elements in the input tensor
+    size_t inputTensorSize = utils::MathUtils::vectorProduct(inputTensorShape);
+
+    // Create a vector from the blob data for ONNX Runtime input
+    std::vector<float> inputTensorValues(blobPtr, blobPtr + inputTensorSize);
+
+    delete[] blobPtr; // Free the allocated memory for the blob
+
+    // Create an Ort memory info object (can be cached if used repeatedly)
+    static Ort::MemoryInfo memoryInfo = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+    // Create input tensor object using the preprocessed data
+    Ort::Value inputTensor = Ort::Value::CreateTensor<float>(
+        memoryInfo,
+        inputTensorValues.data(),
+        inputTensorSize,
+        inputTensorShape.data(),
+        inputTensorShape.size()
+    );
+    std::cout << "batch preprocessing completed in: " << duration.count() << " ms" << std::endl;
+    start = std::chrono::high_resolution_clock::now();
+    // Run the inference session with the input tensor and retrieve output tensors
+    std::vector<Ort::Value> outputTensors = session.Run(
+        Ort::RunOptions{nullptr},
+        inputNames.data(),
+        &inputTensor,
+        numInputNodes,
+        outputNames.data(),
+        numOutputNodes
+    );
+    duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+                            std::chrono::high_resolution_clock::now() - start);
+    std::cout << "batch inference completed in: " << duration.count() << " ms" << std::endl;
+
+    // Determine the resized image shape based on input tensor shape
+    start = std::chrono::high_resolution_clock::now();
+    cv::Size resizedImageShape(static_cast<int>(inputTensorShape[3]), static_cast<int>(inputTensorShape[2]));
+
+    std::vector<std::vector<Detection>> alldetections;
+    std::vector<Detection> detections;
+    
+    const std::vector<int64_t> outputShape = outputTensors[0].GetTensorTypeAndShapeInfo().GetShape();
+    std::cout << "outputShape " << outputShape[0] << " " << outputShape[1] << " " << outputShape[2] << " " << outputShape[3] << std::endl;
+    int batch_size = outputShape[0];
+    cv::Mat image;
+    for (size_t i=0;i<batch_size;i++){
+        image = images[i];
+        if(outputShape[2] == 6){
+            // std::cout << "yolo 10 detected" << std::endl;
+            detections = postprocess_yolo10(image.size(), resizedImageShape, outputTensors,i, confThreshold, iouThreshold);
+        }
+        // else if(outputShape[1] == 7){
+        //     // std::cout << "yolo 7 detected" << std::endl;
+        //     detections = postprocess_yolo7(image.size(), resizedImageShape, outputTensors,i, confThreshold, iouThreshold);
+        // }
+        else if(outputShape[2] == 4){
+            std::cout << "yolo nas detected" << std::endl;
+            detections = postprocess_yolonas(image.size(), resizedImageShape, outputTensors,i, confThreshold, iouThreshold);
+        }
+        else{
+            // std::cout << "yolo not 10 detected" << std::endl;
+            detections = postprocess(image.size(), resizedImageShape, outputTensors,i, confThreshold, iouThreshold);
+        }
+        alldetections.push_back(detections);
+    }
+
+    duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+                            std::chrono::high_resolution_clock::now() - start);
+    std::cout << "postporcessing completed in: " << duration.count() << " ms" << std::endl;
+    return alldetections; // Return the vector of detections
 }

--- a/models/export_onnx.py
+++ b/models/export_onnx.py
@@ -1,11 +1,11 @@
 from ultralytics import YOLO
 from ultralytics import NAS
 
-# Load the YOLOv12n model
-
+# Load the YOLO model
 # model = YOLO("yolov5nu.pt")
 # model = YOLO("yolov6n.yaml")
 # model.train(data="coco8.yaml", epochs=50, imgsz=640)
+# model = YOLO("yolov7n.pt")
 # model = YOLO("yolov8n.pt")
 # model = YOLO("yolov9t.pt")
 # model = YOLO("yolov10n.pt")
@@ -13,7 +13,14 @@ from ultralytics import NAS
 # model = YOLO("yolo12n.pt")
 model = NAS("yolo_nas_s.pt")
 
+# Export the model to ONNX format with static batch size (default)
+# model.export(format="onnx")
 
-# Export the model to ONNX format
-model.export(format="onnx")
+# model = YOLO("yolo11n.pt")
+model.export(format="onnx", dynamic=True, opset=11)
+
+# Example: Export with dynamic batch size for batch inference support
+# Uncomment the following lines to export a dynamic model
+# This will create an ONNX model with dynamic batch dimension (batch size = -1)
+# Useful for batch processing multiple images at once
 

--- a/src/batch_image_inference.cpp
+++ b/src/batch_image_inference.cpp
@@ -1,0 +1,120 @@
+/**
+ * @file batch_image_inference.cpp
+ * @brief Batch object detection on multiple images using YOLO models (v5, v7, v8, v9, v10, v11, v12).
+ * 
+ * This file implements batch object detection that utilizes YOLO models with dynamic batch input support.
+ * The application loads multiple images, processes them in batch, and displays the results with bounding boxes.
+ *
+ * Usage Instructions:
+ * 1. Compile the application with the necessary OpenCV and YOLO dependencies.
+ * 2. Provide the model path and image folder or list of images as arguments.
+ * 3. Run the executable to initiate batch object detection.
+ *
+ * Author: Abdalrahman M. Amer, www.linkedin.com/in/abdalrahman-m-amer
+ * Date: 29.09.2024
+ */
+
+#include <opencv2/highgui/highgui.hpp>
+#include <iostream>
+#include <string>
+#include <chrono>
+#include <filesystem>
+#include <algorithm>
+#include "det/YOLO.hpp"
+
+int main(int argc, char* argv[]){
+    namespace fs = std::filesystem;
+    std::string labelsPath = "../models/coco.names";
+    std::string imagePath = "../data/";
+    std::string modelPath = "../models/yolo11n.onnx";
+    std::vector<std::string> imageFiles;
+
+    if(argc > 1){
+        modelPath = argv[1];
+    }
+    if(argc > 2){
+        imagePath = argv[2];
+        if(fs::is_directory(imagePath)){
+            for(const auto& entry : fs::directory_iterator(imagePath)){
+                if(entry.is_regular_file()){
+                    std::string ext = entry.path().extension().string();
+                    std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+                    if(ext == ".jpg" || ext == ".jpeg" || ext == ".png" || ext == ".bmp" || ext == ".tiff" || ext == ".tif"){
+                        imageFiles.push_back(fs::absolute(entry.path()).string());
+                    }
+                }
+            }
+            if(imageFiles.empty()){
+                std::cerr << "No image files found in directory: " << imagePath << std::endl;
+                return -1;
+            }
+        } else if(fs::is_regular_file(imagePath)){
+            imageFiles.push_back(imagePath);
+        } else {
+            std::cerr << "Provided path is not a valid file or directory: " << imagePath << std::endl;
+            return -1;
+        }
+    } else {
+        std::cout << "Usage: " << argv[0] << " <model_path> <image_path_or_folder> [labels_path]\n";
+        std::cout << "No image path provided. Using default directory: " << imagePath << std::endl;
+        for(const auto& entry : fs::directory_iterator(imagePath)){
+            if(entry.is_regular_file()){
+                std::string ext = entry.path().extension().string();
+                std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+                if(ext == ".jpg" || ext == ".jpeg" || ext == ".png" || ext == ".bmp" || ext == ".tiff" || ext == ".tif"){
+                    imageFiles.push_back(fs::absolute(entry.path()).string());
+                }
+            }
+        }
+        if(imageFiles.empty()){
+            std::cerr << "No image files found in default directory: " << imagePath << std::endl;
+            return -1;
+        }
+    }
+    if(argc > 3){
+        labelsPath = argv[3];
+    }
+
+    // Load all images
+    std::vector<cv::Mat> images;
+    for(const auto& imgPath : imageFiles){
+        cv::Mat img = cv::imread(imgPath);
+        if(img.empty()){
+            std::cerr << "Warning: Could not open or find image: " << imgPath << std::endl;
+            continue;
+        }
+        images.push_back(img);
+    }
+    if(images.empty()){
+        std::cerr << "No valid images to process." << std::endl;
+        return -1;
+    }
+
+    bool isGPU = true; // Set to false for CPU processing
+    YOLODetector detector(modelPath, labelsPath, isGPU);
+
+    auto start = std::chrono::high_resolution_clock::now();
+    for (const auto& img : images)
+        std::cout << "image size " << img.size() << std::endl;
+    std::vector<std::vector<Detection>> batchResults = detector.detect(images, 0.45f);
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+                        std::chrono::high_resolution_clock::now() - start);
+    std::cout << "Batch detection completed in: " << duration.count() << " ms" << std::endl;
+
+    for(size_t i = 0; i < batchResults.size(); ++i){
+        std::cout << "\nImage: " << imageFiles[i] << std::endl;
+        std::cout << "Number of detections: " << batchResults[i].size() << std::endl;
+        for(size_t j = 0; j < batchResults[i].size(); ++j){
+            const Detection& det = batchResults[i][j];
+            std::cout << "Detection " << j << ": Class=" << det.classId
+                      << ", Confidence=" << det.conf
+                      << ", Box=(" << det.box.x << "," << det.box.y
+                      << "," << det.box.width << "," << det.box.height << ")" << std::endl;
+        }
+        // Draw bounding boxes on the image
+        detector.drawBoundingBox(images[i], batchResults[i]);
+        cv::imshow("Detections - " + std::to_string(i), images[i]);
+    }
+    cv::waitKey(0);
+    return 0;
+}


### PR DESCRIPTION
Added batch support for the library. Depending on the input the class is going to be able to process multiple images at once.

Fixed a problem in the "auto_" condition in the letterbox which was giving inconsistent resized images shapes.

The only model that has issues with the current implementation is yolo7. The reason is it doesn't have one way of being exported as it's not supported directly by ultralytics. 

It can be exported as end2end model (which is what the post processing function is considering now). In this case the outputs are just 7 values for one image.

The issue when multiple images are there, detections are listed after each other without separation (N x 7).  

The end2end does some NMS and postprocessing that's why. We can support yolo7 without end2end instead and in this case we can have similar functions to other yolo models. 