### PR TITLE
Add yolov8 & v5 classification support

### DIFF
--- a/include/class/YOLOCLASS.hpp
+++ b/include/class/YOLOCLASS.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-// One-file unified YOLO classifier (merges YOLO11 and YOLO12 implementations)
+// Unified YOLO classifier header (now supports YOLOv8, YOLOv11, and YOLOv12)
 
 #include <onnxruntime_cxx_api.h>
 #include <opencv2/opencv.hpp>
@@ -23,6 +23,9 @@
 #include "tools/Debug.hpp"
 #include "tools/ScopedTimer.hpp"
 
+// -----------------------------
+// Classification result struct
+// -----------------------------
 struct ClassificationResult {
     int classId{-1};
     float confidence{0.0f};
@@ -33,6 +36,9 @@ struct ClassificationResult {
         : classId(id), confidence(conf), className(std::move(name)) {}
 };
 
+// -----------------------------
+// Utility namespace
+// -----------------------------
 namespace utils {
     template <typename T>
     typename std::enable_if<std::is_arithmetic<T>::value, T>::type
@@ -113,6 +119,9 @@ namespace utils {
     }
 } // namespace utils
 
+// -----------------------------
+// Base classifier (shared logic)
+// -----------------------------
 class BaseYOLOClassifier {
 public:
     BaseYOLOClassifier(const std::string &modelPath, const std::string &labelsPath,
@@ -124,13 +133,14 @@ public:
     }
     cv::Size getInputShape() const { return inputImageShape_; }
     bool isModelInputShapeDynamic() const { return isDynamicInputShape_; }
-private:
+
+protected:
     Ort::Env env_{nullptr};
     Ort::SessionOptions sessionOptions_{nullptr};
     Ort::Session session_{nullptr};
     bool isDynamicInputShape_{};
     cv::Size inputImageShape_{};
-    std::vector<float> inputBuffer_{}; // persistent input buffer to avoid reallocations
+    std::vector<float> inputBuffer_{};
     std::vector<Ort::AllocatedStringPtr> inputNodeNameAllocatedStrings_{};
     std::vector<const char *> inputNames_{};
     std::vector<Ort::AllocatedStringPtr> outputNodeNameAllocatedStrings_{};
@@ -138,71 +148,91 @@ private:
     size_t numInputNodes_{}, numOutputNodes_{};
     int numClasses_{0};
     std::vector<std::string> classNames_{};
+
     void preprocess(const cv::Mat &image, float *&blob, std::vector<int64_t> &inputTensorShape);
     ClassificationResult postprocess(const std::vector<Ort::Value> &outputTensors);
 };
 
-inline BaseYOLOClassifier::BaseYOLOClassifier(const std::string &modelPath, const std::string &labelsPath,
-                                 bool useGPU, const cv::Size& targetInputShape)
-    : inputImageShape_(targetInputShape) {
+// -----------------------------
+// Constructor implementation
+// -----------------------------
+inline BaseYOLOClassifier::BaseYOLOClassifier(const std::string &modelPath,
+        const std::string &labelsPath,
+        bool useGPU,
+        const cv::Size& targetInputShape) {
     env_ = Ort::Env(ORT_LOGGING_LEVEL_WARNING, "ONNX_CLASSIFICATION_ENV");
     sessionOptions_ = Ort::SessionOptions();
     sessionOptions_.SetIntraOpNumThreads(std::min(4, static_cast<int>(std::thread::hardware_concurrency())));
     sessionOptions_.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_ALL);
+
     std::vector<std::string> availableProviders = Ort::GetAvailableProviders();
     auto cudaAvailable = std::find(availableProviders.begin(), availableProviders.end(), "CUDAExecutionProvider");
     OrtCUDAProviderOptions cudaOption{};
     if (useGPU && cudaAvailable != availableProviders.end()) {
         sessionOptions_.AppendExecutionProvider_CUDA(cudaOption);
     }
+
 #ifdef _WIN32
     std::wstring w_modelPath = std::wstring(modelPath.begin(), modelPath.end());
     session_ = Ort::Session(env_, w_modelPath.c_str(), sessionOptions_);
 #else
     session_ = Ort::Session(env_, modelPath.c_str(), sessionOptions_);
 #endif
+
     Ort::AllocatorWithDefaultOptions allocator;
     numInputNodes_ = session_.GetInputCount();
     numOutputNodes_ = session_.GetOutputCount();
+
     auto input_node_name = session_.GetInputNameAllocated(0, allocator);
     inputNodeNameAllocatedStrings_.push_back(std::move(input_node_name));
     inputNames_.push_back(inputNodeNameAllocatedStrings_.back().get());
+
     Ort::TypeInfo inputTypeInfo = session_.GetInputTypeInfo(0);
     auto inputTensorInfo = inputTypeInfo.GetTensorTypeAndShapeInfo();
     std::vector<int64_t> modelInputTensorShapeVec = inputTensorInfo.GetShape();
+
     if (modelInputTensorShapeVec.size() == 4) {
         isDynamicInputShape_ = (modelInputTensorShapeVec[2] == -1 || modelInputTensorShapeVec[3] == -1);
         if (!isDynamicInputShape_) {
             int modelH = static_cast<int>(modelInputTensorShapeVec[2]);
             int modelW = static_cast<int>(modelInputTensorShapeVec[3]);
-            if (modelH != inputImageShape_.height || modelW != inputImageShape_.width) {
-                std::cout << "Warning: Target preprocessing shape (" << inputImageShape_.height << "x" << inputImageShape_.width
-                          << ") differs from model's fixed input shape (" << modelH << "x" << modelW << "). "
-                          << "Image will be preprocessed to " << inputImageShape_.height << "x" << inputImageShape_.width << "." << std::endl;
-            }
+            inputImageShape_ = cv::Size(modelW, modelH);
+        } else {
+            inputImageShape_ = targetInputShape;
         }
     } else {
         isDynamicInputShape_ = true;
+        inputImageShape_ = targetInputShape;
     }
+
     auto output_node_name = session_.GetOutputNameAllocated(0, allocator);
     outputNodeNameAllocatedStrings_.push_back(std::move(output_node_name));
     outputNames_.push_back(outputNodeNameAllocatedStrings_.back().get());
+
     Ort::TypeInfo outputTypeInfo = session_.GetOutputTypeInfo(0);
     auto outputTensorInfo = outputTypeInfo.GetTensorTypeAndShapeInfo();
     std::vector<int64_t> outputTensorShapeVec = outputTensorInfo.GetShape();
+
     if (!outputTensorShapeVec.empty()) {
-        if (outputTensorShapeVec.size() == 2 && outputTensorShapeVec[0] > 0) {
+        if (outputTensorShapeVec.size() == 2 && outputTensorShapeVec[0] > 0)
             numClasses_ = static_cast<int>(outputTensorShapeVec[1]);
-        } else if (outputTensorShapeVec.size() == 1 && outputTensorShapeVec[0] > 0) {
+        else if (outputTensorShapeVec.size() == 1 && outputTensorShapeVec[0] > 0)
             numClasses_ = static_cast<int>(outputTensorShapeVec[0]);
-        } else {
-            for (long long dim : outputTensorShapeVec) if (dim > 1 && numClasses_ == 0) numClasses_ = static_cast<int>(dim);
-            if (numClasses_ == 0 && !outputTensorShapeVec.empty()) numClasses_ = static_cast<int>(outputTensorShapeVec.back());
+        else {
+            for (long long dim : outputTensorShapeVec)
+                if (dim > 1 && numClasses_ == 0)
+                    numClasses_ = static_cast<int>(dim);
+            if (numClasses_ == 0 && !outputTensorShapeVec.empty())
+                numClasses_ = static_cast<int>(outputTensorShapeVec.back());
         }
     }
+
     classNames_ = utils::getClassNames(labelsPath);
 }
 
+// -----------------------------
+// Preprocessing + postprocessing
+// -----------------------------
 inline void BaseYOLOClassifier::preprocess(const cv::Mat &image, float *&blob, std::vector<int64_t> &inputTensorShape) {
     ScopedTimer timer("Preprocessing (Ultralytics-style)");
     if (image.empty()) throw std::runtime_error("Input image to preprocess is empty.");
@@ -229,12 +259,20 @@ inline ClassificationResult BaseYOLOClassifier::postprocess(const std::vector<Or
     const float* rawOutput = outputTensors[0].GetTensorData<float>(); if (!rawOutput) return {};
     const std::vector<int64_t> outputShape = outputTensors[0].GetTensorTypeAndShapeInfo().GetShape();
     size_t numScores = utils::vectorProduct(outputShape);
-    int currentNumClasses = numClasses_ > 0 ? numClasses_ : static_cast<int>(classNames_.size()); if (currentNumClasses <= 0) return {};
-    int bestClassId = -1; float maxScore = -std::numeric_limits<float>::infinity(); std::vector<float> scores(currentNumClasses);
+    int currentNumClasses = numClasses_ > 0 ? numClasses_ : static_cast<int>(classNames_.size());
+    if (currentNumClasses <= 0) return {};
+    int bestClassId = -1; float maxScore = -std::numeric_limits<float>::infinity();
+    std::vector<float> scores(currentNumClasses);
     if (outputShape.size() == 2 && outputShape[0] == 1) {
-        for (int i = 0; i < currentNumClasses && i < static_cast<int>(outputShape[1]); ++i) { scores[i] = rawOutput[i]; if (scores[i] > maxScore) { maxScore = scores[i]; bestClassId = i; } }
+        for (int i = 0; i < currentNumClasses && i < static_cast<int>(outputShape[1]); ++i) {
+            scores[i] = rawOutput[i];
+            if (scores[i] > maxScore) { maxScore = scores[i]; bestClassId = i; }
+        }
     } else {
-        for (int i = 0; i < currentNumClasses && i < static_cast<int>(numScores); ++i) { scores[i] = rawOutput[i]; if (scores[i] > maxScore) { maxScore = scores[i]; bestClassId = i; } }
+        for (int i = 0; i < currentNumClasses && i < static_cast<int>(numScores); ++i) {
+            scores[i] = rawOutput[i];
+            if (scores[i] > maxScore) { maxScore = scores[i]; bestClassId = i; }
+        }
     }
     if (bestClassId == -1) return {};
     float sumExp = 0.0f; std::vector<float> probabilities(currentNumClasses);
@@ -255,52 +293,89 @@ inline ClassificationResult BaseYOLOClassifier::classify(const cv::Mat& image) {
     return postprocess(outputTensors);
 }
 
-// Thin wrappers for versioned classifiers
-class YOLO11Classifier : public BaseYOLOClassifier {
-public:
-    using BaseYOLOClassifier::BaseYOLOClassifier;
-};
-
-class YOLO12Classifier : public BaseYOLOClassifier {
-public:
-    using BaseYOLOClassifier::BaseYOLOClassifier;
-};
-
-enum class YOLOClassVersion { V11, V12 };
-
-class YOLOClassifier {
-public:
-    YOLOClassifier(const std::string &modelPath,
-                   const std::string &labelsPath,
-                   bool useGPU = false,
-                   YOLOClassVersion version = YOLOClassVersion::V11)
-    {
-        if (version == YOLOClassVersion::V11) {
-            impl_.template emplace<YOLO11Classifier>(modelPath, labelsPath, useGPU);
-        } else {
-            impl_.template emplace<YOLO12Classifier>(modelPath, labelsPath, useGPU);
+// -----------------------------
+// Derived classifiers
+// -----------------------------
+class YOLO5Classifier : public BaseYOLOClassifier {
+    public:
+        using BaseYOLOClassifier::BaseYOLOClassifier;
+    };
+    
+    class YOLO8Classifier : public BaseYOLOClassifier {
+    public:
+        using BaseYOLOClassifier::BaseYOLOClassifier;
+    };
+    
+    class YOLO11Classifier : public BaseYOLOClassifier {
+    public:
+        using BaseYOLOClassifier::BaseYOLOClassifier;
+    };
+    
+    class YOLO12Classifier : public BaseYOLOClassifier {
+    public:
+        using BaseYOLOClassifier::BaseYOLOClassifier;
+    };
+    
+    // -----------------------------
+    // Unified interface
+    // -----------------------------
+    enum class YOLOClassVersion { V5, V8, V11, V12 };
+    
+    class YOLOClassifier {
+    public:
+        YOLOClassifier(const std::string &modelPath,
+                       const std::string &labelsPath,
+                       bool useGPU = false,
+                       YOLOClassVersion version = YOLOClassVersion::V11) {
+            switch (version) {
+                case YOLOClassVersion::V5:
+                    impl_.template emplace<YOLO5Classifier>(modelPath, labelsPath, useGPU);
+                    break;
+                case YOLOClassVersion::V8:
+                    impl_.template emplace<YOLO8Classifier>(modelPath, labelsPath, useGPU);
+                    break;
+                case YOLOClassVersion::V11:
+                    impl_.template emplace<YOLO11Classifier>(modelPath, labelsPath, useGPU);
+                    break;
+                case YOLOClassVersion::V12:
+                    impl_.template emplace<YOLO12Classifier>(modelPath, labelsPath, useGPU);
+                    break;
+            }
         }
-    }
-    ClassificationResult classify(const cv::Mat &image) {
-        if (auto *p = std::get_if<YOLO11Classifier>(&impl_)) return p->classify(image);
-        if (auto *q = std::get_if<YOLO12Classifier>(&impl_)) return q->classify(image);
-        return {};
-    }
-    void drawResult(cv::Mat &image, const ClassificationResult &result,
-                    const cv::Point &position = cv::Point(10, 10)) const {
-        if (auto *p = std::get_if<YOLO11Classifier>(&impl_)) { p->drawResult(image, result, position); return; }
-        if (auto *q = std::get_if<YOLO12Classifier>(&impl_)) { q->drawResult(image, result, position); return; }
-    }
-    cv::Size getInputShape() const {
-        if (auto *p = std::get_if<YOLO11Classifier>(&impl_)) return p->getInputShape();
-        if (auto *q = std::get_if<YOLO12Classifier>(&impl_)) return q->getInputShape();
-        return cv::Size();
-    }
-    bool isModelInputShapeDynamic() const {
-        if (auto *p = std::get_if<YOLO11Classifier>(&impl_)) return p->isModelInputShapeDynamic();
-        if (auto *q = std::get_if<YOLO12Classifier>(&impl_)) return q->isModelInputShapeDynamic();
-        return true;
-    }
-private:
-    std::variant<std::monostate, YOLO11Classifier, YOLO12Classifier> impl_;
-};
+    
+        ClassificationResult classify(const cv::Mat &image) {
+            if (auto *p = std::get_if<YOLO5Classifier>(&impl_)) return p->classify(image);
+            if (auto *p = std::get_if<YOLO8Classifier>(&impl_)) return p->classify(image);
+            if (auto *p = std::get_if<YOLO11Classifier>(&impl_)) return p->classify(image);
+            if (auto *p = std::get_if<YOLO12Classifier>(&impl_)) return p->classify(image);
+            return {};
+        }
+    
+        void drawResult(cv::Mat &image, const ClassificationResult &result,
+                        const cv::Point &position = cv::Point(10, 10)) const {
+            if (auto *p = std::get_if<YOLO5Classifier>(&impl_)) { p->drawResult(image, result, position); return; }
+            if (auto *p = std::get_if<YOLO8Classifier>(&impl_)) { p->drawResult(image, result, position); return; }
+            if (auto *p = std::get_if<YOLO11Classifier>(&impl_)) { p->drawResult(image, result, position); return; }
+            if (auto *p = std::get_if<YOLO12Classifier>(&impl_)) { p->drawResult(image, result, position); return; }
+        }
+    
+        cv::Size getInputShape() const {
+            if (auto *p = std::get_if<YOLO5Classifier>(&impl_)) return p->getInputShape();
+            if (auto *p = std::get_if<YOLO8Classifier>(&impl_)) return p->getInputShape();
+            if (auto *p = std::get_if<YOLO11Classifier>(&impl_)) return p->getInputShape();
+            if (auto *p = std::get_if<YOLO12Classifier>(&impl_)) return p->getInputShape();
+            return cv::Size();
+        }
+    
+        bool isModelInputShapeDynamic() const {
+            if (auto *p = std::get_if<YOLO5Classifier>(&impl_)) return p->isModelInputShapeDynamic();
+            if (auto *p = std::get_if<YOLO8Classifier>(&impl_)) return p->isModelInputShapeDynamic();
+            if (auto *p = std::get_if<YOLO11Classifier>(&impl_)) return p->isModelInputShapeDynamic();
+            if (auto *p = std::get_if<YOLO12Classifier>(&impl_)) return p->isModelInputShapeDynamic();
+            return true;
+        }
+    
+    private:
+        std::variant<std::monostate, YOLO5Classifier, YOLO8Classifier, YOLO11Classifier, YOLO12Classifier> impl_;
+    };
+    

--- a/src/class_image_inference.cpp
+++ b/src/class_image_inference.cpp
@@ -7,13 +7,13 @@
 
 int main(int argc, char** argv){
     const std::string labelsPath = "../models/coco.names";     // detection labels; use proper labels for your model
-    const std::string imagePath  = "../data/dog2.jpg";         // change to your image
-    const std::string modelPath  = "../models/yolo11l-cls.onnx";   // classification ONNX
-    int versionArg = 12;
+    const std::string imagePath  = "../data/dog.jpg";         // change to your image
+    const std::string modelPath  = "../models/yolov8n-cls.onnx";   // classification ONNX
+    int versionArg = 5;
 
     // Init classifier
-    bool useGPU = true;    
-    YOLOClassVersion ver = (versionArg == 11) ? YOLOClassVersion::V11 : YOLOClassVersion::V12;
+    bool useGPU = false;    
+    YOLOClassVersion ver = (versionArg == 5) ? YOLOClassVersion::V5 : YOLOClassVersion::V8;
     YOLOClassifier classifier(modelPath, labelsPath, useGPU, ver);
 
     // Load image


### PR DESCRIPTION

yolov8 classification added directly to YOLOCLASS.hpp module, allowing to run classification alongside existing YOLOv11 and YOLOv12 model support.

Introduced new yolo8 class inheriting from BaseYOLOClassifier and
updated YOLOClassifier unified interface and enum to include v8.

overview for yolov5:

Add a YOLO5Classifier class (inherits from BaseYOLOClassifier).

Update the YOLOClassVersion enum(add V5).

Extend the unified YOLOClassifier wrapper to handle YOLOv5.

example image classified
<img width="298" height="270" alt="image" src="https://github.com/user-attachments/assets/dcfcf6e5-4986-427d-9ac7-132b35d31c62" />
