### PR TITLE
feat: add grayscale input support

### DIFF
--- a/include/yolos/core/preprocessing.hpp
+++ b/include/yolos/core/preprocessing.hpp
@@ -266,11 +266,13 @@ inline void getLetterboxParams(const cv::Size& originalShape,
 /// @brief Fast letterbox with direct blob output (avoids intermediate copies)
 /// @param image Input BGR image
 /// @param blob Output CHW float blob (pre-allocated)
+/// @param targetChannels Target channels for inference
 /// @param targetSize Target size for inference
 /// @param[out] actualSize Actual output size after letterboxing
 /// @param padColor Padding color value (0-255, default 114)
 inline void letterBoxToBlob(const cv::Mat& image,
                             std::vector<float>& blob,
+                            int targetChannels,
                             const cv::Size& targetSize,
                             cv::Size& actualSize,
                             float padColor = 114.0f) {
@@ -297,7 +299,7 @@ inline void letterBoxToBlob(const cv::Mat& image,
     actualSize = cv::Size(dstW, dstH);
     
     // Ensure blob capacity
-    const size_t totalSize = static_cast<size_t>(dstH * dstW * 3);
+    const size_t totalSize = static_cast<size_t>(dstH * dstW * targetChannels);
     if (blob.size() < totalSize) {
         blob.resize(totalSize);
     }
@@ -314,26 +316,42 @@ inline void letterBoxToBlob(const cv::Mat& image,
         resized = image;
     }
     
-    // Convert BGR to RGB and normalize directly into blob (CHW format)
-    float* rChannel = blob.data();
-    float* gChannel = blob.data() + dstH * dstW;
-    float* bChannel = blob.data() + 2 * dstH * dstW;
-    
     constexpr float scale255 = 1.0f / 255.0f;
-    
-    for (int y = 0; y < newH; ++y) {
-        const int dstY = y + padTop;
-        const uchar* row = resized.ptr<uchar>(y);
+    if (targetChannels == 3) {
+        // Convert BGR to RGB and normalize directly into blob (CHW format)
+        float* rChannel = blob.data();
+        float* gChannel = blob.data() + dstH * dstW;
+        float* bChannel = blob.data() + 2 * dstH * dstW;
         
-        for (int x = 0; x < newW; ++x) {
-            const int dstX = x + padLeft;
-            const int dstIdx = dstY * dstW + dstX;
-            const int srcIdx = x * 3;
+        for (int y = 0; y < newH; ++y) {
+            const int dstY = y + padTop;
+            const uchar* row = resized.ptr<uchar>(y);
             
-            // BGR to RGB conversion + normalization
-            bChannel[dstIdx] = row[srcIdx + 0] * scale255;
-            gChannel[dstIdx] = row[srcIdx + 1] * scale255;
-            rChannel[dstIdx] = row[srcIdx + 2] * scale255;
+            for (int x = 0; x < newW; ++x) {
+                const int dstX = x + padLeft;
+                const int dstIdx = dstY * dstW + dstX;
+                const int srcIdx = x * 3;
+                
+                // BGR to RGB conversion + normalization
+                bChannel[dstIdx] = row[srcIdx + 0] * scale255;
+                gChannel[dstIdx] = row[srcIdx + 1] * scale255;
+                rChannel[dstIdx] = row[srcIdx + 2] * scale255;
+            }
+        }
+    } else {
+        // normalize directly into blob (single channel)
+        float *channel = blob.data();
+
+        for (int y = 0; y < newH; ++y) {
+            const int    dstY = y + padTop;
+            const uchar *row  = resized.ptr<uchar>(y);
+
+            for (int x = 0; x < newW; ++x) {
+                const int dstX   = x + padLeft;
+                const int dstIdx = dstY * dstW + dstX;
+
+                channel[dstIdx] = static_cast<float>(row[x]) * scale255;
+            }
         }
     }
 }
@@ -341,11 +359,13 @@ inline void letterBoxToBlob(const cv::Mat& image,
 /// @brief Fast letterbox with buffer reuse
 /// @param image Input BGR image
 /// @param buffer Pre-allocated inference buffer
+/// @param targetChannels Target channels for inference
 /// @param targetSize Target size for inference
 /// @param[out] actualSize Actual output size
 /// @param dynamicShape Whether to use dynamic shape
 inline void letterBoxToBlob(const cv::Mat& image,
                             InferenceBuffer& buffer,
+                            int targetChannels,
                             const cv::Size& targetSize,
                             cv::Size& actualSize,
                             bool dynamicShape = false) {
@@ -371,7 +391,7 @@ inline void letterBoxToBlob(const cv::Mat& image,
     }
     
     actualSize = cv::Size(dstW, dstH);
-    buffer.ensureCapacity(dstH, dstW, 3);
+    buffer.ensureCapacity(dstH, dstW, targetChannels);
     
     // Ultralytics uses asymmetric padding with -0.1/+0.1 adjustment
     const float dh = (dstH - newH) / 2.0f;
@@ -381,7 +401,7 @@ inline void letterBoxToBlob(const cv::Mat& image,
     
     // Fill with padding (normalized 114/255)
     constexpr float padNorm = 114.0f / 255.0f;
-    std::fill(buffer.blob.begin(), buffer.blob.begin() + dstH * dstW * 3, padNorm);
+    std::fill(buffer.blob.begin(), buffer.blob.begin() + dstH * dstW * targetChannels, padNorm);
     
     // Resize if needed
     if (newW != srcW || newH != srcH) {
@@ -390,28 +410,41 @@ inline void letterBoxToBlob(const cv::Mat& image,
         buffer.resized = image;  // Reference, no copy
     }
     
-    // Direct BGR->RGB + normalize to CHW blob
-    float* rChannel = buffer.blob.data();
-    float* gChannel = buffer.blob.data() + dstH * dstW;
-    float* bChannel = buffer.blob.data() + 2 * dstH * dstW;
-    
     constexpr float scale255 = 1.0f / 255.0f;
-    
-    for (int y = 0; y < newH; ++y) {
-        const int dstY = y + padTop;
-        const uchar* row = buffer.resized.ptr<uchar>(y);
-        const int rowOffset = dstY * dstW + padLeft;
+    if (targetChannels == 3) {
+        // Direct BGR->RGB + normalize to CHW blob
+        float* rChannel = buffer.blob.data();
+        float* gChannel = buffer.blob.data() + dstH * dstW;
+        float* bChannel = buffer.blob.data() + 2 * dstH * dstW;
         
-        for (int x = 0; x < newW; ++x) {
-            const int dstIdx = rowOffset + x;
-            const int srcIdx = x * 3;
+        for (int y = 0; y < newH; ++y) {
+            const int dstY = y + padTop;
+            const uchar* row = buffer.resized.ptr<uchar>(y);
+            const int rowOffset = dstY * dstW + padLeft;
             
-            bChannel[dstIdx] = row[srcIdx + 0] * scale255;
-            gChannel[dstIdx] = row[srcIdx + 1] * scale255;
-            rChannel[dstIdx] = row[srcIdx + 2] * scale255;
+            for (int x = 0; x < newW; ++x) {
+                const int dstIdx = rowOffset + x;
+                const int srcIdx = x * 3;
+                
+                bChannel[dstIdx] = row[srcIdx + 0] * scale255;
+                gChannel[dstIdx] = row[srcIdx + 1] * scale255;
+                rChannel[dstIdx] = row[srcIdx + 2] * scale255;
+            }
+        }
+    } else {
+        // normalize directly into blob (single channel)
+        float* blobPtr = buffer.blob.data();
+        for (int y = 0; y < newH; ++y) {
+            const int dstY = y + padTop;
+            const uchar* row = buffer.resized.ptr<uchar>(y);
+            const int rowOffset = dstY * dstW + padLeft;
+            
+            for (int x = 0; x < newW; ++x) {
+                blobPtr[rowOffset + x] = static_cast<float>(row[x]) * scale255;
+            }
         }
     }
-    
+
     buffer.lastInputSize = cv::Size(srcW, srcH);
     buffer.lastTargetSize = actualSize;
 }

--- a/include/yolos/core/session_base.hpp
+++ b/include/yolos/core/session_base.hpp
@@ -83,6 +83,7 @@ protected:
     size_t numInputNodes_{0};
     size_t numOutputNodes_{0};
 
+    int inputChannels_{3};
     cv::Size inputShape_;
     bool isDynamicInputShape_{false};
     bool isDynamicBatchSize_{false};
@@ -181,6 +182,7 @@ private:
             isDynamicBatchSize_ = (inputTensorShape[0] == -1);
             isDynamicInputShape_ = (inputTensorShape[2] == -1 || inputTensorShape[3] == -1);
 
+            inputChannels_ = (inputTensorShape[1] == -1) ? 3 : static_cast<int>(inputTensorShape[1]);
             int height = (inputTensorShape[2] == -1) ? 640 : static_cast<int>(inputTensorShape[2]);
             int width = (inputTensorShape[3] == -1) ? 640 : static_cast<int>(inputTensorShape[3]);
             inputShape_ = cv::Size(width, height);

--- a/include/yolos/tasks/detection.hpp
+++ b/include/yolos/tasks/detection.hpp
@@ -63,7 +63,7 @@ public:
         classColors_ = drawing::generateColors(classNames_);
         
         // Pre-allocate inference buffer
-        buffer_.ensureCapacity(inputShape_.height, inputShape_.width, 3);
+        buffer_.ensureCapacity(inputShape_.height, inputShape_.width, inputChannels_);
     }
 
     virtual ~YOLODetector() = default;
@@ -78,10 +78,10 @@ public:
                                           float iouThreshold = 0.45f) {
         // Optimized preprocessing with buffer reuse
         cv::Size actualSize;
-        preprocessing::letterBoxToBlob(image, buffer_, inputShape_, actualSize, isDynamicInputShape_);
-        
+        preprocessing::letterBoxToBlob(image, buffer_, inputChannels_, inputShape_, actualSize, isDynamicInputShape_);
+
         // Create input tensor (uses pre-allocated blob)
-        std::vector<int64_t> inputTensorShape = {1, 3, actualSize.height, actualSize.width};
+        std::vector<int64_t> inputTensorShape = {1, static_cast<int64_t>(inputChannels_), actualSize.height, actualSize.width};
         Ort::Value inputTensor = createInputTensor(buffer_.blob.data(), inputTensorShape);
 
         // Run inference

--- a/include/yolos/tasks/obb.hpp
+++ b/include/yolos/tasks/obb.hpp
@@ -66,7 +66,7 @@ public:
         classColors_ = drawing::generateColors(classNames_);
         
         // Pre-allocate inference buffer
-        buffer_.ensureCapacity(inputShape_.height, inputShape_.width, 3);
+        buffer_.ensureCapacity(inputShape_.height, inputShape_.width, inputChannels_);
     }
 
     virtual ~YOLOOBBDetector() = default;
@@ -83,10 +83,10 @@ public:
                                   int maxDet = 300) {
         // Optimized preprocessing with buffer reuse
         cv::Size actualSize;
-        preprocessing::letterBoxToBlob(image, buffer_, inputShape_, actualSize, isDynamicInputShape_);
+        preprocessing::letterBoxToBlob(image, buffer_, inputChannels_, inputShape_, actualSize, isDynamicInputShape_);
 
         // Create input tensor (uses pre-allocated blob)
-        std::vector<int64_t> inputTensorShape = {1, 3, actualSize.height, actualSize.width};
+        std::vector<int64_t> inputTensorShape = {1, static_cast<int64_t>(inputChannels_), actualSize.height, actualSize.width};
         Ort::Value inputTensor = createInputTensor(buffer_.blob.data(), inputTensorShape);
 
         // Run inference

--- a/include/yolos/tasks/pose.hpp
+++ b/include/yolos/tasks/pose.hpp
@@ -68,7 +68,7 @@ public:
         classColors_ = drawing::generateColors(classNames_);
         
         // Pre-allocate inference buffer
-        buffer_.ensureCapacity(inputShape_.height, inputShape_.width, 3);
+        buffer_.ensureCapacity(inputShape_.height, inputShape_.width, inputChannels_);
     }
 
     virtual ~YOLOPoseDetector() = default;
@@ -83,10 +83,10 @@ public:
                                    float iouThreshold = 0.5f) {
         // Optimized preprocessing with buffer reuse
         cv::Size actualSize;
-        preprocessing::letterBoxToBlob(image, buffer_, inputShape_, actualSize, isDynamicInputShape_);
+        preprocessing::letterBoxToBlob(image, buffer_, inputChannels_, inputShape_, actualSize, isDynamicInputShape_);
 
         // Create input tensor (uses pre-allocated blob)
-        std::vector<int64_t> inputTensorShape = {1, 3, actualSize.height, actualSize.width};
+        std::vector<int64_t> inputTensorShape = {1, static_cast<int64_t>(inputChannels_), actualSize.height, actualSize.width};
         Ort::Value inputTensor = createInputTensor(buffer_.blob.data(), inputTensorShape);
 
         // Run inference

--- a/include/yolos/tasks/segmentation.hpp
+++ b/include/yolos/tasks/segmentation.hpp
@@ -68,7 +68,7 @@ public:
         classColors_ = drawing::generateColors(classNames_);
         
         // Pre-allocate inference buffer
-        buffer_.ensureCapacity(inputShape_.height, inputShape_.width, 3);
+        buffer_.ensureCapacity(inputShape_.height, inputShape_.width, inputChannels_);
     }
 
     virtual ~YOLOSegDetector() = default;
@@ -83,10 +83,10 @@ public:
                                       float iouThreshold = 0.45f) {
         // Optimized preprocessing with buffer reuse
         cv::Size actualSize;
-        preprocessing::letterBoxToBlob(image, buffer_, inputShape_, actualSize, isDynamicInputShape_);
+        preprocessing::letterBoxToBlob(image, buffer_, inputChannels_, inputShape_, actualSize, isDynamicInputShape_);
 
         // Create input tensor (uses pre-allocated blob)
-        std::vector<int64_t> inputTensorShape = {1, 3, actualSize.height, actualSize.width};
+        std::vector<int64_t> inputTensorShape = {1, static_cast<int64_t>(inputChannels_), actualSize.height, actualSize.width};
         Ort::Value inputTensor = createInputTensor(buffer_.blob.data(), inputTensorShape);
 
         // Run inference


### PR DESCRIPTION
Support for models of grayscale input, e.g. [COCO8-Grayscale](https://github.com/ultralytics/ultralytics/blob/main/docs/en/datasets/detect/coco8-grayscale.md).

> To train your RGB images in grayscale, you could simply add `channels: 1` to your dataset YAML file. This converts all images to grayscale during training, enabling you to utilize grayscale benefits without requiring a separate dataset.