### PR TITLE
fix(cmake): include project headers when built as subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,10 @@ endif()
 # ============================================================================
 function(add_yolo_executable name source)
     add_executable(${name} ${source})
-    target_include_directories(${name} PRIVATE "${ONNXRUNTIME_DIR}/include")
+    target_include_directories(${name} PRIVATE 
+        "${CMAKE_CURRENT_SOURCE_DIR}/include"
+        "${ONNXRUNTIME_DIR}/include"    
+    )
     target_link_libraries(${name} PRIVATE 
         ${OpenCV_LIBS}
         ${ONNXRUNTIME_LIB}


### PR DESCRIPTION
Fixes header resolution when YOLOs-CPP is built as a add_subdirectory for another cmake project.

When building using `add_subdirectory(YOLOs-CPP)` for other projects, the header files aren't found (eg. `fatal error: yolos/tasks/detection.hpp: No such file or directory`). This one line changes that.