### PR TITLE
feat: in-memory model loading and batch inference (#143)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
           ./build/image_inference --help || true
 
   # ==========================================================================
-  # Test Suite (Detection, Segmentation, Pose, OBB, Classification, YOLOE)
+  # Test Suite (Detection, Segmentation, Pose, OBB, Classification, YOLOE, API)
   # ==========================================================================
   test-suite:
     runs-on: ubuntu-latest
@@ -76,7 +76,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        task: [detection, segmentation, pose, obb, classification, yoloe]
+        task: [detection, segmentation, pose, obb, classification, yoloe, api]
     
     steps:
       - name: Checkout repository
@@ -113,8 +113,9 @@ jobs:
           chmod +x test_${{ matrix.task }}.sh
           ./test_${{ matrix.task }}.sh
 
+      # The api suite asserts library behavior in-process and writes no results
       - name: Upload test results
-        if: always()
+        if: always() && matrix.task != 'api'
         uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ matrix.task }}

--- a/README.md
+++ b/README.md
@@ -73,8 +73,10 @@ YOLOs-CPP unifies everything under one roof:
 |--------------|-------------|
 | **Unified API** | Same interface for YOLOv5 through YOLO26 |
 | **All Tasks** | Detection, Segmentation, Pose, OBB, Classification, [YOLOE](docs/guides/models.md#yoloe-open-vocabulary-detection-segmentation) open-vocabulary |
-| **Battle-Tested** | 36 automated tests, CI/CD pipeline |
+| **Battle-Tested** | 44 Ultralytics-parity tests + 22 API tests, CI/CD pipeline |
 | **Optimized** | Zero-copy preprocessing, batched NMS, GPU acceleration |
+| **Batch Inference** | `batchDetect` / `batchSegment` / `batchClassify` in one ONNX call, [with fallback](docs/api/api.md#batch-inference) |
+| **Flexible Loading** | Models from a file path or [straight from memory](docs/api/api.md#in-memory-model-loading) (encrypted stores, network streams, embedded resources) |
 | **Cross-Platform** | Linux, Windows, macOS, Docker |
 
 ---
@@ -187,10 +189,12 @@ Open-vocabulary [YOLOE](docs/guides/models.md#yoloe-open-vocabulary-detection-se
 ### Core Capabilities
 
 - **🚀 High Performance**: Zero-copy preprocessing, optimized NMS, GPU acceleration
-- **🎯 Precision Matched**: Identical results to Ultralytics Python (validated by 36 automated tests)
+- **🎯 Precision Matched**: Identical results to Ultralytics Python (validated by 44 parity tests)
 - **📦 Self-Contained**: No Python runtime, no external dependencies at runtime
 - **🔌 Easy Integration**: Header-based library, modern C++17 API
 - **⚙️ Flexible**: CPU/GPU, dynamic/static input shapes, configurable thresholds
+- **📚 Batch Inference**: Multiple images per ONNX Runtime call, with automatic per-image fallback for fixed-batch exports
+- **🔐 In-Memory Models**: Load ONNX bytes directly — no file on disk required
 
 ---
 
@@ -249,6 +253,45 @@ detector.drawOBBs(frame, boxes);
 yolos::cls::YOLOClassifier classifier("yolo11n-cls.onnx", "imagenet.names", true);
 auto result = classifier.classify(frame);
 std::cout << "Predicted: " << result.className << " (" << result.confidence * 100 << "%)" << std::endl;
+```
+
+### Batch Inference
+
+One ONNX Runtime call for many images — the throughput win on GPU. Requires a model
+exported with `dynamic=True`; fixed-batch exports fall back to a per-image loop
+automatically, so the call works either way. See
+[Batch Inference](docs/api/api.md#batch-inference).
+
+```cpp
+std::vector<cv::Mat> images = {cv::imread("a.jpg"), cv::imread("b.jpg"), cv::imread("c.jpg")};
+
+yolos::det::YOLODetector detector("yolo11n.onnx", "coco.names", /*gpu=*/true);
+
+// One result vector per input image, in input order
+auto results = detector.batchDetect(images, /*conf=*/0.25f, /*iou=*/0.45f);
+
+// Also: batchSegment(), batchClassify(), and batchDetect() for pose and OBB
+```
+
+```bash
+./build/batch_image_inference models/yolo11n.onnx data/ models/coco.names
+```
+
+### In-Memory Model Loading
+
+For encrypted stores, network streams and resources embedded in the binary — the model
+never needs to exist as a file. See
+[In-Memory Model Loading](docs/api/api.md#in-memory-model-loading).
+
+```cpp
+// Bytes from anywhere: decryption, download, embedded array
+std::vector<uint8_t> bytes = yolos::utils::readFileBytes("yolo11n.onnx");
+
+// Class names come in as a vector, so no labels file is needed either
+yolos::det::YOLODetector detector(bytes.data(), bytes.size(), {"person", "bicycle", "car"});
+
+// ONNX Runtime copied the buffer during construction — safe to wipe it now
+auto detections = detector.detect(frame);
 ```
 
 ### YOLOE (open-vocabulary segmentation)

--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -79,9 +79,25 @@ YOLODetector(
     YOLOVersion        version = YOLOVersion::Auto
 );
 
+// Load the model from memory instead of a file (see In-Memory Model Loading)
+YOLODetector(
+    const void*                     modelData,
+    size_t                          modelSize,
+    const std::vector<std::string>& classNames,  // empty = read ONNX metadata
+    bool                            useGPU = false,
+    YOLOVersion                     version = YOLOVersion::Auto
+);
+
 // Run detection on a BGR image
 std::vector<Detection> detect(
     const cv::Mat& image,
+    float confThreshold = 0.4f,
+    float iouThreshold  = 0.45f
+);
+
+// Run detection on many images in one ONNX Runtime call (see Batch Inference)
+std::vector<std::vector<Detection>> batchDetect(
+    const std::vector<cv::Mat>& images,
     float confThreshold = 0.4f,
     float iouThreshold  = 0.45f
 );
@@ -108,7 +124,7 @@ const std::vector<cv::Scalar>&  getClassColors() const;
 | `yolos::det::YOLO26Detector` | v26 |
 | `yolos::det::YOLONASDetector` | NAS |
 
-**Factory function:**
+**Factory functions:**
 
 ```cpp
 std::unique_ptr<YOLODetector> yolos::det::createDetector(
@@ -116,6 +132,14 @@ std::unique_ptr<YOLODetector> yolos::det::createDetector(
     const std::string& labelsPath,
     YOLOVersion        version = YOLOVersion::Auto,
     bool               useGPU = false
+);
+
+std::unique_ptr<YOLODetector> yolos::det::createDetectorFromMemory(
+    const void*                     modelData,
+    size_t                          modelSize,
+    const std::vector<std::string>& classNames,
+    YOLOVersion                     version = YOLOVersion::Auto,
+    bool                            useGPU = false
 );
 ```
 
@@ -155,9 +179,24 @@ YOLOSegDetector(
     bool               useGPU = false
 );
 
+// Load the model from memory instead of a file (see In-Memory Model Loading)
+YOLOSegDetector(
+    const void*                     modelData,
+    size_t                          modelSize,
+    const std::vector<std::string>& classNames,  // empty = read ONNX metadata
+    bool                            useGPU = false
+);
+
 // Returns detections with per-instance binary masks
 std::vector<Segmentation> segment(
     const cv::Mat& image,
+    float confThreshold = 0.4f,
+    float iouThreshold  = 0.45f
+);
+
+// Segment many images in one ONNX Runtime call (see Batch Inference)
+std::vector<std::vector<Segmentation>> batchSegment(
+    const std::vector<cv::Mat>& images,
     float confThreshold = 0.4f,
     float iouThreshold  = 0.45f
 );
@@ -206,8 +245,23 @@ YOLOPoseDetector(
     bool               useGPU = false
 );
 
+// Load the model from memory instead of a file (see In-Memory Model Loading)
+YOLOPoseDetector(
+    const void*                     modelData,
+    size_t                          modelSize,
+    const std::vector<std::string>& classNames = {},  // empty = metadata, then "person"
+    bool                            useGPU = false
+);
+
 std::vector<PoseResult> detect(
     const cv::Mat& image,
+    float confThreshold = 0.4f,
+    float iouThreshold  = 0.5f
+);
+
+// Detect on many images in one ONNX Runtime call (see Batch Inference)
+std::vector<std::vector<PoseResult>> batchDetect(
+    const std::vector<cv::Mat>& images,
     float confThreshold = 0.4f,
     float iouThreshold  = 0.5f
 );
@@ -256,8 +310,24 @@ YOLOOBBDetector(
     bool               useGPU = false
 );
 
+// Load the model from memory instead of a file (see In-Memory Model Loading)
+YOLOOBBDetector(
+    const void*                     modelData,
+    size_t                          modelSize,
+    const std::vector<std::string>& classNames,  // empty = read ONNX metadata
+    bool                            useGPU = false
+);
+
 std::vector<OBBResult> detect(
     const cv::Mat& image,
+    float confThreshold = 0.25f,
+    float iouThreshold  = 0.45f,
+    int   maxDet = 300
+);
+
+// Detect on many images in one ONNX Runtime call (see Batch Inference)
+std::vector<std::vector<OBBResult>> batchDetect(
+    const std::vector<cv::Mat>& images,
     float confThreshold = 0.25f,
     float iouThreshold  = 0.45f,
     int   maxDet = 300
@@ -303,7 +373,19 @@ YOLOClassifier(
     const cv::Size&    targetInputShape = cv::Size(224, 224)
 );
 
+// Load the model from memory instead of a file (see In-Memory Model Loading)
+YOLOClassifier(
+    const void*                     modelData,
+    size_t                          modelSize,
+    const std::vector<std::string>& classNames,
+    bool                            useGPU = false,
+    const cv::Size&                 targetInputShape = cv::Size(224, 224)
+);
+
 ClassificationResult classify(const cv::Mat& image);
+
+// Classify many images in one ONNX Runtime call (see Batch Inference)
+std::vector<ClassificationResult> batchClassify(const std::vector<cv::Mat>& images);
 
 void drawResult(cv::Mat& image, const ClassificationResult& result,
                 const cv::Point& position = cv::Point(10, 30)) const;
@@ -319,7 +401,7 @@ const std::vector<std::string>& getClassNames() const;
 | `yolos::cls::YOLO12Classifier` | v12 |
 | `yolos::cls::YOLO26Classifier` | v26 |
 
-**Factory function:**
+**Factory functions:**
 
 ```cpp
 std::unique_ptr<YOLOClassifier> yolos::cls::createClassifier(
@@ -327,6 +409,14 @@ std::unique_ptr<YOLOClassifier> yolos::cls::createClassifier(
     const std::string& labelsPath,
     YOLOVersion        version = YOLOVersion::V11,
     bool               useGPU = false
+);
+
+std::unique_ptr<YOLOClassifier> yolos::cls::createClassifierFromMemory(
+    const void*                     modelData,
+    size_t                          modelSize,
+    const std::vector<std::string>& classNames,
+    YOLOVersion                     version = YOLOVersion::V11,
+    bool                            useGPU = false
 );
 ```
 
@@ -355,12 +445,103 @@ segmentation, pose, OBB) really does use `cv2.INTER_LINEAR`, so those paths keep
 Defined in `yolos/core/session_base.hpp`. All detectors inherit from this — you normally don't need to use it directly.
 
 ```cpp
-cv::Size    getInputShape()     const noexcept;
+cv::Size    getInputShape()       const noexcept;
 bool        isDynamicInputShape() const noexcept;
-std::string getDevice()         const noexcept;  // "cpu" or "gpu"
-size_t      getNumInputNodes()  const noexcept;
-size_t      getNumOutputNodes() const noexcept;
+bool        isDynamicBatchSize()  const noexcept;  // true if the ONNX batch dim is dynamic
+int         getModelBatchSize()   const noexcept;  // fixed batch size, or -1 if dynamic
+bool        supportsBatchSize(size_t count) const noexcept;  // can one call take `count` images?
+std::string getDevice()           const noexcept;  // "cpu" or "gpu"
+size_t      getNumInputNodes()    const noexcept;
+size_t      getNumOutputNodes()   const noexcept;
 ```
+
+---
+
+## In-Memory Model Loading
+
+Every task class has a constructor that takes the serialized ONNX bytes instead of a
+file path, for encrypted stores, network streams and resources embedded in the binary.
+Class names are passed as a `std::vector<std::string>` in class-id order, so no labels
+file is needed either.
+
+```cpp
+// Whatever produces the bytes — decryption, download, embedded array — only the
+// buffer reaches the detector.
+std::vector<uint8_t> bytes = yolos::utils::readFileBytes("yolo11n.onnx");
+
+yolos::det::YOLODetector detector(
+    bytes.data(), bytes.size(),
+    {"person", "bicycle", "car" /* ... */});
+
+auto results = detector.detect(frame);
+```
+
+Notes:
+
+- ONNX Runtime **copies** the buffer while creating the session, so the caller may
+  free or wipe it as soon as the constructor returns.
+- Passing an empty `classNames` falls back to the Ultralytics `names` entry in the
+  ONNX metadata, when the export carries one.
+- A null pointer or zero size throws `std::invalid_argument`.
+- `yolos::utils::readFileBytes(path)` is a convenience helper for testing this path;
+  production callers normally supply their own bytes.
+
+Constructors and matching `create*FromMemory()` factories exist for detection,
+segmentation, pose, OBB, classification and YOLOE.
+
+---
+
+## Batch Inference
+
+`batchDetect` / `batchSegment` / `batchClassify` pack several images into a single
+`N × C × H × W` tensor and run one ONNX Runtime call, which is what improves GPU
+throughput over calling the single-image method in a loop.
+
+```cpp
+std::vector<cv::Mat> images = {cv::imread("a.jpg"), cv::imread("b.jpg"), cv::imread("c.jpg")};
+
+yolos::det::YOLODetector detector("yolo11n.onnx", "coco.names", /*useGPU=*/true);
+
+// One result vector per input image, in input order
+std::vector<std::vector<yolos::det::Detection>> results = detector.batchDetect(images);
+```
+
+| Task | Method | Returns |
+|---|---|---|
+| Detection | `batchDetect(images, conf, iou)` | `std::vector<std::vector<Detection>>` |
+| Segmentation | `batchSegment(images, conf, iou)` | `std::vector<std::vector<Segmentation>>` |
+| Pose | `batchDetect(images, conf, iou)` | `std::vector<std::vector<PoseResult>>` |
+| OBB | `batchDetect(images, conf, iou, maxDet)` | `std::vector<std::vector<OBBResult>>` |
+| Classification | `batchClassify(images)` | `std::vector<ClassificationResult>` |
+
+**Automatic fallback.** True batching needs a model whose batch dimension accepts the
+batch size — either a dynamic batch dim, or a fixed one equal to `images.size()`. When
+it does not, the batch methods loop over the single-image path instead, so the call
+still returns one result per image with any export. The same recovery covers exports
+that *declare* a dynamic batch dimension the graph cannot actually run (hard-coded
+`Reshape` targets, for example): the failure is reported as a warning and the per-image
+loop takes over. Check up front with:
+
+```cpp
+detector.isDynamicBatchSize();               // was the model exported with dynamic=True?
+detector.getModelBatchSize();                // fixed batch size, or -1 when dynamic
+detector.supportsBatchSize(images.size());   // will this call actually batch?
+```
+
+Export a dynamic-batch model from Ultralytics with:
+
+```python
+model.export(format="onnx", dynamic=True)
+```
+
+**Behavioral note.** A batched tensor requires one shared letterbox target, so batched
+runs letterbox every image to the model input shape. For a model with a *dynamic input
+shape*, the single-image methods instead pick a per-image stride-aligned shape, so the
+two paths can differ slightly for such models. Fixed-input-shape models — the common
+case — produce identical results either way.
+
+Runnable demo: `src/batch_image_inference.cpp` (`--in-memory` also exercises the
+in-memory loader).
 
 ---
 

--- a/docs/examples/examples.md
+++ b/docs/examples/examples.md
@@ -114,6 +114,45 @@ while (cap.read(frame)) {
 }
 ```
 
+## Batch Inference
+
+One ONNX Runtime call for a whole batch instead of one call per image — the throughput
+win on GPU. See [Batch Inference](../api/api.md#batch-inference) for the fallback rules.
+
+```cpp
+std::vector<cv::Mat> images = {cv::imread("a.jpg"), cv::imread("b.jpg"), cv::imread("c.jpg")};
+
+// One result vector per input image, in input order
+auto results = detector.batchDetect(images, /*conf=*/0.25f, /*iou=*/0.45f);
+
+for (size_t i = 0; i < images.size(); ++i) {
+    detector.drawDetections(images[i], results[i]);
+}
+```
+
+Requires a model exported with `model.export(format="onnx", dynamic=True)`. Fixed-batch
+exports fall back to a per-image loop automatically — check with
+`detector.supportsBatchSize(images.size())`.
+
+The same pattern applies to `batchSegment()`, `batchClassify()`, and `batchDetect()` on
+the pose and OBB detectors.
+
+## Loading a Model From Memory
+
+For encrypted stores, network streams and resources embedded in the binary. See
+[In-Memory Model Loading](../api/api.md#in-memory-model-loading).
+
+```cpp
+// Bytes from anywhere; readFileBytes() is just a convenience helper
+std::vector<uint8_t> bytes = yolos::utils::readFileBytes("yolo11n.onnx");
+
+// Class names as a vector, so no labels file is needed either
+yolos::det::YOLODetector detector(bytes.data(), bytes.size(), {"person", "bicycle", "car"});
+
+// ONNX Runtime copied the buffer during construction — safe to wipe it now
+auto detections = detector.detect(frame);
+```
+
 ## Camera Stream
 
 ```cpp
@@ -136,6 +175,7 @@ while (cap.read(frame)) {
 2. **Use GPU when available** — 5-10x faster than CPU
 3. **Adjust thresholds** — Higher confidence = fewer detections, faster NMS
 4. **Match input resolution** — Use model's expected size (640x640)
+5. **Batch when you have several images** — `batchDetect()` amortizes one ONNX call across the batch (needs a `dynamic=True` export)
 
 ## Error Handling
 

--- a/include/yolos/core/preprocessing.hpp
+++ b/include/yolos/core/preprocessing.hpp
@@ -263,51 +263,45 @@ inline void getLetterboxParams(const cv::Size& originalShape,
 // Optimized Single-Pass Preprocessing
 // ============================================================================
 
-/// @brief Fast letterbox with direct blob output (avoids intermediate copies)
+/// @brief Fast letterbox writing directly into a caller-owned CHW float slice
 /// @param image Input BGR image
-/// @param blob Output CHW float blob (pre-allocated)
+/// @param dst Destination CHW slice; must hold at least
+///            targetChannels * targetSize.height * targetSize.width floats
 /// @param targetChannels Target channels for inference
-/// @param targetSize Target size for inference
-/// @param[out] actualSize Actual output size after letterboxing
+/// @param targetSize Target size for inference (used verbatim, no stride alignment)
 /// @param padColor Padding color value (0-255, default 114)
-inline void letterBoxToBlob(const cv::Mat& image,
-                            std::vector<float>& blob,
-                            int targetChannels,
-                            const cv::Size& targetSize,
-                            cv::Size& actualSize,
-                            float padColor = 114.0f) {
-    
+/// @note Only the requested slice is written, so this is safe to use for one
+///       image of a batched N*C*H*W blob.
+inline void letterBoxToBlobPtr(const cv::Mat& image,
+                               float* dst,
+                               int targetChannels,
+                               const cv::Size& targetSize,
+                               float padColor = 114.0f) {
+
     const int srcH = image.rows;
     const int srcW = image.cols;
     const int dstH = targetSize.height;
     const int dstW = targetSize.width;
-    
+
     // Calculate scale and padding (match Ultralytics exactly)
     const float scale = std::min(static_cast<float>(dstH) / srcH,
                                   static_cast<float>(dstW) / srcW);
-    
+
     // Ultralytics uses round() for new dimensions
     const int newH = static_cast<int>(std::round(srcH * scale));
     const int newW = static_cast<int>(std::round(srcW * scale));
-    
+
     // Ultralytics uses asymmetric padding with -0.1/+0.1 adjustment
     const float dh = (dstH - newH) / 2.0f;
     const float dw = (dstW - newW) / 2.0f;
     const int padTop = static_cast<int>(std::round(dh - 0.1f));
     const int padLeft = static_cast<int>(std::round(dw - 0.1f));
-    
-    actualSize = cv::Size(dstW, dstH);
-    
-    // Ensure blob capacity
-    const size_t totalSize = static_cast<size_t>(dstH * dstW * targetChannels);
-    if (blob.size() < totalSize) {
-        blob.resize(totalSize);
-    }
-    
-    // Fill with padding color (normalized)
+
+    // Fill this slice with padding color (normalized)
+    const size_t sliceSize = static_cast<size_t>(dstH) * dstW * targetChannels;
     const float padNorm = padColor / 255.0f;
-    std::fill(blob.begin(), blob.end(), padNorm);
-    
+    std::fill(dst, dst + sliceSize, padNorm);
+
     // Resize image
     cv::Mat resized;
     if (newW != srcW || newH != srcH) {
@@ -315,23 +309,23 @@ inline void letterBoxToBlob(const cv::Mat& image,
     } else {
         resized = image;
     }
-    
+
     constexpr float scale255 = 1.0f / 255.0f;
     if (targetChannels == 3) {
         // Convert BGR to RGB and normalize directly into blob (CHW format)
-        float* rChannel = blob.data();
-        float* gChannel = blob.data() + dstH * dstW;
-        float* bChannel = blob.data() + 2 * dstH * dstW;
-        
+        float* rChannel = dst;
+        float* gChannel = dst + dstH * dstW;
+        float* bChannel = dst + 2 * dstH * dstW;
+
         for (int y = 0; y < newH; ++y) {
             const int dstY = y + padTop;
             const uchar* row = resized.ptr<uchar>(y);
-            
+
             for (int x = 0; x < newW; ++x) {
                 const int dstX = x + padLeft;
                 const int dstIdx = dstY * dstW + dstX;
                 const int srcIdx = x * 3;
-                
+
                 // BGR to RGB conversion + normalization
                 bChannel[dstIdx] = row[srcIdx + 0] * scale255;
                 gChannel[dstIdx] = row[srcIdx + 1] * scale255;
@@ -340,7 +334,7 @@ inline void letterBoxToBlob(const cv::Mat& image,
         }
     } else {
         // normalize directly into blob (single channel)
-        float *channel = blob.data();
+        float *channel = dst;
 
         for (int y = 0; y < newH; ++y) {
             const int    dstY = y + padTop;
@@ -353,6 +347,57 @@ inline void letterBoxToBlob(const cv::Mat& image,
                 channel[dstIdx] = static_cast<float>(row[x]) * scale255;
             }
         }
+    }
+}
+
+/// @brief Fast letterbox with direct blob output (avoids intermediate copies)
+/// @param image Input BGR image
+/// @param blob Output CHW float blob (resized if too small)
+/// @param targetChannels Target channels for inference
+/// @param targetSize Target size for inference
+/// @param[out] actualSize Actual output size after letterboxing
+/// @param padColor Padding color value (0-255, default 114)
+inline void letterBoxToBlob(const cv::Mat& image,
+                            std::vector<float>& blob,
+                            int targetChannels,
+                            const cv::Size& targetSize,
+                            cv::Size& actualSize,
+                            float padColor = 114.0f) {
+
+    actualSize = targetSize;
+
+    // Ensure blob capacity
+    const size_t totalSize = static_cast<size_t>(targetSize.height) * targetSize.width * targetChannels;
+    if (blob.size() < totalSize) {
+        blob.resize(totalSize);
+    }
+
+    letterBoxToBlobPtr(image, blob.data(), targetChannels, targetSize, padColor);
+}
+
+/// @brief Letterbox a batch of images into a single contiguous N*C*H*W blob
+/// @param images Input BGR images
+/// @param blob Output N*C*H*W float blob (resized if too small)
+/// @param targetChannels Target channels for inference
+/// @param targetSize Target size shared by every image in the batch
+/// @param padColor Padding color value (0-255, default 114)
+/// @note All images share one letterbox target, which is what a batched tensor
+///       requires. Per-image scale/padding still differ and must be recovered
+///       with getScalePad(images[i].size(), targetSize, ...) during postprocessing.
+inline void letterBoxToBatchBlob(const std::vector<cv::Mat>& images,
+                                 std::vector<float>& blob,
+                                 int targetChannels,
+                                 const cv::Size& targetSize,
+                                 float padColor = 114.0f) {
+
+    const size_t sliceSize = static_cast<size_t>(targetSize.height) * targetSize.width * targetChannels;
+    const size_t totalSize = sliceSize * images.size();
+    if (blob.size() < totalSize) {
+        blob.resize(totalSize);
+    }
+
+    for (size_t i = 0; i < images.size(); ++i) {
+        letterBoxToBlobPtr(images[i], blob.data() + i * sliceSize, targetChannels, targetSize, padColor);
     }
 }
 

--- a/include/yolos/core/session_base.hpp
+++ b/include/yolos/core/session_base.hpp
@@ -14,11 +14,13 @@
 #include <algorithm>
 #include <iostream>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <vector>
 
 #include "yolos/core/onnx_metadata.hpp"
+#include "yolos/core/preprocessing.hpp"
 #include "yolos/core/utils.hpp"
 #include "yolos/core/version.hpp"
 
@@ -38,8 +40,39 @@ public:
     /// @param numThreads Number of intra-op threads (0 = auto)
     OrtSessionBase(const std::string& modelPath, bool useGPU = false, int numThreads = 0)
         : env_(ORT_LOGGING_LEVEL_WARNING, "YOLOS") {
-        
-        initSession(modelPath, useGPU, numThreads);
+
+        configureSessionOptions(useGPU, numThreads);
+
+#ifdef _WIN32
+        std::wstring wModelPath(modelPath.begin(), modelPath.end());
+        session_ = Ort::Session(env_, wModelPath.c_str(), sessionOptions_);
+#else
+        session_ = Ort::Session(env_, modelPath.c_str(), sessionOptions_);
+#endif
+
+        introspectSession(modelPath);
+    }
+
+    /// @brief Constructor - initializes the ONNX model from an in-memory buffer
+    /// @param modelData Pointer to the serialized ONNX model bytes
+    /// @param modelSize Size of the buffer in bytes
+    /// @param useGPU Whether to use GPU (CUDA) for inference
+    /// @param numThreads Number of intra-op threads (0 = auto)
+    /// @note ONNX Runtime copies the buffer while creating the session, so the
+    ///       caller may free @p modelData as soon as the constructor returns.
+    ///       Useful for encrypted stores, network streams and embedded resources.
+    OrtSessionBase(const void* modelData, size_t modelSize, bool useGPU = false, int numThreads = 0)
+        : env_(ORT_LOGGING_LEVEL_WARNING, "YOLOS") {
+
+        if (modelData == nullptr || modelSize == 0) {
+            throw std::invalid_argument("Model buffer is empty (modelData == nullptr or modelSize == 0).");
+        }
+
+        configureSessionOptions(useGPU, numThreads);
+
+        session_ = Ort::Session(env_, modelData, modelSize, sessionOptions_);
+
+        introspectSession("<memory buffer, " + std::to_string(modelSize) + " bytes>");
     }
 
     virtual ~OrtSessionBase() = default;
@@ -60,6 +93,17 @@ public:
 
     /// @brief Check if batch size is dynamic
     [[nodiscard]] bool isDynamicBatchSize() const noexcept { return isDynamicBatchSize_; }
+
+    /// @brief Fixed batch size baked into the model, or -1 when the batch dim is dynamic
+    [[nodiscard]] int getModelBatchSize() const noexcept { return modelBatchSize_; }
+
+    /// @brief Whether a single ONNX call can process exactly @p count images
+    /// Dynamic-batch models accept any count; fixed-batch models only their own.
+    [[nodiscard]] bool supportsBatchSize(size_t count) const noexcept {
+        if (count == 0) return false;
+        if (isDynamicBatchSize_) return true;
+        return modelBatchSize_ == static_cast<int>(count);
+    }
 
     /// @brief Get the device being used for inference
     [[nodiscard]] const std::string& getDevice() const noexcept { return device_; }
@@ -93,6 +137,7 @@ protected:
     cv::Size inputShape_;
     bool isDynamicInputShape_{false};
     bool isDynamicBatchSize_{false};
+    int modelBatchSize_{1};
     std::string device_{"cpu"};
 
     /// Ultralytics-exported `names` dict parsed from ONNX metadata (empty if missing).
@@ -129,8 +174,91 @@ protected:
         );
     }
 
+    /// @brief Letterbox a batch of images and run a single batched inference
+    /// @param images Input BGR images (all letterboxed to the same target size)
+    /// @param blob Scratch buffer reused across calls for the N*C*H*W input
+    /// @param[out] letterboxSize Shared letterbox size used for every image
+    /// @return Output tensors with a leading batch dimension of images.size()
+    /// @note Batching forces one common letterbox target (the model input shape),
+    ///       so dynamic-input-shape models do not get per-image stride alignment
+    ///       here the way the single-image paths do.
+    std::vector<Ort::Value> runBatchInference(const std::vector<cv::Mat>& images,
+                                              std::vector<float>& blob,
+                                              cv::Size& letterboxSize) {
+        letterboxSize = inputShape_;
+        preprocessing::letterBoxToBatchBlob(images, blob, inputChannels_, letterboxSize);
+
+        const std::vector<int64_t> inputTensorShape = {
+            static_cast<int64_t>(images.size()),
+            static_cast<int64_t>(inputChannels_),
+            letterboxSize.height,
+            letterboxSize.width
+        };
+
+        Ort::Value inputTensor = createInputTensor(blob.data(), inputTensorShape);
+        return runInference(inputTensor);
+    }
+
+    /// @brief Check that every model output is a float tensor
+    /// The batch-slicing helper below only understands float tensors.
+    [[nodiscard]] bool allOutputsAreFloat() const {
+        for (size_t i = 0; i < numOutputNodes_; ++i) {
+            Ort::TypeInfo info = session_.GetOutputTypeInfo(i);
+            if (info.GetONNXType() != ONNX_TYPE_TENSOR ||
+                info.GetTensorTypeAndShapeInfo().GetElementType() !=
+                    ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /// @brief Build zero-copy single-image views into batched output tensors
+    /// @param batchOutputs Output tensors produced by a batched run
+    /// @param batchIndex Index of the image to view
+    /// @param batchSize Batch size the run was made with
+    /// @return Tensors shaped [1, ...] aliasing @p batchOutputs (no data copied)
+    /// @note The returned views borrow @p batchOutputs' memory, so they must not
+    ///       outlive it. Slicing lets the existing single-image postprocessing
+    ///       (including subclass overrides) run unchanged on each batch element.
+    static std::vector<Ort::Value> sliceOutputBatch(std::vector<Ort::Value>& batchOutputs,
+                                                    int64_t batchIndex,
+                                                    int64_t batchSize) {
+        static Ort::MemoryInfo memoryInfo = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+
+        std::vector<Ort::Value> views;
+        views.reserve(batchOutputs.size());
+
+        for (auto& tensor : batchOutputs) {
+            std::vector<int64_t> shape = tensor.GetTensorTypeAndShapeInfo().GetShape();
+            float* data = tensor.GetTensorMutableData<float>();
+
+            // Outputs whose leading dimension is not the batch cannot be sliced;
+            // share them whole so postprocessing still sees the full tensor.
+            if (shape.empty() || shape[0] != batchSize) {
+                views.push_back(Ort::Value::CreateTensor<float>(
+                    memoryInfo, data, utils::vectorProduct(shape), shape.data(), shape.size()));
+                continue;
+            }
+
+            std::vector<int64_t> sliceShape = shape;
+            sliceShape[0] = 1;
+            const size_t sliceElems = utils::vectorProduct(sliceShape);
+
+            views.push_back(Ort::Value::CreateTensor<float>(
+                memoryInfo,
+                data + static_cast<size_t>(batchIndex) * sliceElems,
+                sliceElems,
+                sliceShape.data(),
+                sliceShape.size()
+            ));
+        }
+
+        return views;
+    }
+
 private:
-    void initSession(const std::string& modelPath, bool useGPU, int numThreads) {
+    void configureSessionOptions(bool useGPU, int numThreads) {
         sessionOptions_ = Ort::SessionOptions();
 
         // Set thread count
@@ -154,15 +282,11 @@ private:
             device_ = "cpu";
             std::cout << "[INFO] Inference device: CPU" << std::endl;
         }
+    }
 
-        // Load model
-#ifdef _WIN32
-        std::wstring wModelPath(modelPath.begin(), modelPath.end());
-        session_ = Ort::Session(env_, wModelPath.c_str(), sessionOptions_);
-#else
-        session_ = Ort::Session(env_, modelPath.c_str(), sessionOptions_);
-#endif
-
+    /// @brief Read node names, shapes and metadata from an already-created session
+    /// @param modelLabel Human-readable model identifier used only for logging
+    void introspectSession(const std::string& modelLabel) {
         // Get node counts
         numInputNodes_ = session_.GetInputCount();
         numOutputNodes_ = session_.GetOutputCount();
@@ -188,7 +312,8 @@ private:
         std::vector<int64_t> inputTensorShape = inputTypeInfo.GetTensorTypeAndShapeInfo().GetShape();
 
         if (inputTensorShape.size() >= 4) {
-            isDynamicBatchSize_ = (inputTensorShape[0] == -1);
+            isDynamicBatchSize_ = (inputTensorShape[0] <= 0);
+            modelBatchSize_ = isDynamicBatchSize_ ? -1 : static_cast<int>(inputTensorShape[0]);
             isDynamicInputShape_ = (inputTensorShape[2] == -1 || inputTensorShape[3] == -1);
 
             inputChannels_ = (inputTensorShape[1] == -1) ? 3 : static_cast<int>(inputTensorShape[1]);
@@ -199,9 +324,12 @@ private:
             throw std::runtime_error("Invalid input tensor shape. Expected 4D tensor [N, C, H, W].");
         }
 
-        std::cout << "[INFO] Model loaded: " << modelPath << std::endl;
+        std::cout << "[INFO] Model loaded: " << modelLabel << std::endl;
         std::cout << "[INFO] Input shape: " << inputShape_.width << "x" << inputShape_.height
                   << (isDynamicInputShape_ ? " (dynamic)" : "") << std::endl;
+        std::cout << "[INFO] Batch size: "
+                  << (isDynamicBatchSize_ ? std::string("dynamic") : std::to_string(modelBatchSize_))
+                  << std::endl;
         std::cout << "[INFO] Inputs: " << numInputNodes_ << ", Outputs: " << numOutputNodes_ << std::endl;
 
         try {

--- a/include/yolos/core/utils.hpp
+++ b/include/yolos/core/utils.hpp
@@ -99,6 +99,38 @@ inline std::vector<std::string> getClassNames(const std::string& path) {
     return classNames;
 }
 
+/// @brief Read a whole file into memory
+/// @param path Path to the file
+/// @return File contents; empty vector on failure
+/// @note Convenience helper for the in-memory model-loading constructors. Real
+///       callers typically get their bytes from an encrypted store, a network
+///       stream or an embedded resource instead.
+inline std::vector<uint8_t> readFileBytes(const std::string& path) {
+    std::vector<uint8_t> bytes;
+    std::ifstream file(path, std::ios::binary | std::ios::ate);
+
+    if (!file) {
+        std::cerr << "[ERROR] Failed to open file: " << path << std::endl;
+        return bytes;
+    }
+
+    const std::streamsize size = file.tellg();
+    if (size <= 0) {
+        std::cerr << "[ERROR] File is empty: " << path << std::endl;
+        return bytes;
+    }
+
+    file.seekg(0, std::ios::beg);
+    bytes.resize(static_cast<size_t>(size));
+
+    if (!file.read(reinterpret_cast<char*>(bytes.data()), size)) {
+        std::cerr << "[ERROR] Failed to read file: " << path << std::endl;
+        bytes.clear();
+    }
+
+    return bytes;
+}
+
 // ============================================================================
 // Sigmoid Activation
 // ============================================================================

--- a/include/yolos/tasks/classification.hpp
+++ b/include/yolos/tasks/classification.hpp
@@ -21,6 +21,7 @@
 #include <memory>
 #include <numeric>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <vector>
@@ -109,9 +110,46 @@ public:
                    const cv::Size& targetInputShape = cv::Size(224, 224))
         : inputImageShape_(targetInputShape),
           env_(ORT_LOGGING_LEVEL_WARNING, "YOLOClassifier") {
-        
-        initSession(modelPath, useGPU);
+
+        configureSessionOptions(useGPU);
+
+#ifdef _WIN32
+        std::wstring wModelPath(modelPath.begin(), modelPath.end());
+        session_ = Ort::Session(env_, wModelPath.c_str(), sessionOptions_);
+#else
+        session_ = Ort::Session(env_, modelPath.c_str(), sessionOptions_);
+#endif
+
+        introspectSession(modelPath);
         classNames_ = utils::getClassNames(labelsPath);
+    }
+
+    /// @brief Constructor loading the model from memory instead of a file
+    /// @param modelData Pointer to the serialized ONNX model bytes
+    /// @param modelSize Size of the buffer in bytes
+    /// @param classNames Class names in class-id order
+    /// @param useGPU Whether to use GPU for inference
+    /// @param targetInputShape Target input shape for preprocessing
+    /// @note ONNX Runtime copies the buffer during session creation, so
+    ///       @p modelData may be freed once the constructor returns.
+    YOLOClassifier(const void* modelData,
+                   size_t modelSize,
+                   const std::vector<std::string>& classNames,
+                   bool useGPU = false,
+                   const cv::Size& targetInputShape = cv::Size(224, 224))
+        : inputImageShape_(targetInputShape),
+          env_(ORT_LOGGING_LEVEL_WARNING, "YOLOClassifier") {
+
+        if (modelData == nullptr || modelSize == 0) {
+            throw std::invalid_argument("Model buffer is empty (modelData == nullptr or modelSize == 0).");
+        }
+
+        configureSessionOptions(useGPU);
+
+        session_ = Ort::Session(env_, modelData, modelSize, sessionOptions_);
+
+        introspectSession("<memory buffer, " + std::to_string(modelSize) + " bytes>");
+        classNames_ = classNames;
     }
 
     virtual ~YOLOClassifier() = default;
@@ -144,6 +182,40 @@ public:
         return postprocess(outputTensors);
     }
 
+    /// @brief Run classification on several images with a single ONNX Runtime call
+    /// @param images Input images (BGR format)
+    /// @return One result per input image, in input order
+    /// @note Packs the batch into one N*3*H*W tensor when the model accepts the
+    ///       batch size (dynamic batch dimension, or a fixed one that matches
+    ///       images.size()); otherwise falls back to classify() per image.
+    ///       Empty inputs yield a default-constructed result at their position.
+    std::vector<ClassificationResult> batchClassify(const std::vector<cv::Mat>& images) {
+        std::vector<ClassificationResult> results;
+        if (images.empty()) return results;
+
+        const bool anyEmpty = std::any_of(images.begin(), images.end(),
+                                          [](const cv::Mat& m) { return m.empty(); });
+        const bool canBatch = !anyEmpty &&
+                              (isDynamicBatchSize_ || modelBatchSize_ == static_cast<int>(images.size()));
+
+        if (canBatch) {
+            try {
+                return batchClassifyPacked(images);
+            } catch (const Ort::Exception& e) {
+                // Some exports declare a dynamic batch dimension the graph cannot
+                // actually run (hard-coded Reshape targets, for instance).
+                std::cerr << "[WARNING] Batched inference failed (" << e.what()
+                          << "). Falling back to per-image inference." << std::endl;
+            }
+        }
+
+        results.reserve(images.size());
+        for (const auto& image : images) {
+            results.push_back(classify(image));
+        }
+        return results;
+    }
+
     /// @brief Draw classification result on an image
     void drawResult(cv::Mat& image, const ClassificationResult& result,
                     const cv::Point& position = cv::Point(10, 30)) const {
@@ -156,6 +228,12 @@ public:
     /// @brief Check if input shape is dynamic
     [[nodiscard]] bool isDynamicInputShape() const { return isDynamicInputShape_; }
 
+    /// @brief Check if the model's batch dimension is dynamic
+    [[nodiscard]] bool isDynamicBatchSize() const { return isDynamicBatchSize_; }
+
+    /// @brief Fixed batch size baked into the model, or -1 when the batch dim is dynamic
+    [[nodiscard]] int getModelBatchSize() const { return modelBatchSize_; }
+
     /// @brief Get class names
     [[nodiscard]] const std::vector<std::string>& getClassNames() const { return classNames_; }
 
@@ -165,6 +243,8 @@ protected:
     Ort::SessionOptions sessionOptions_{nullptr};
     Ort::Session session_{nullptr};
     bool isDynamicInputShape_{false};
+    bool isDynamicBatchSize_{false};
+    int modelBatchSize_{1};
     std::vector<float> inputBuffer_;
 
     std::vector<Ort::AllocatedStringPtr> inputNameAllocs_;
@@ -177,7 +257,52 @@ protected:
     int numClasses_{0};
     std::vector<std::string> classNames_;
 
-    void initSession(const std::string& modelPath, bool useGPU) {
+    /// @brief Single batched ONNX call plus per-image postprocessing
+    /// Throws Ort::Exception if the model cannot run the requested batch size.
+    std::vector<ClassificationResult> batchClassifyPacked(const std::vector<cv::Mat>& images) {
+        // Every image is center-cropped to the same square, so one shared shape works
+        const int targetSize = inputImageShape_.width;
+        const size_t sliceSize = static_cast<size_t>(3) * targetSize * targetSize;
+        inputBuffer_.resize(sliceSize * images.size());
+
+        for (size_t i = 0; i < images.size(); ++i) {
+            preprocessInto(images[i], inputBuffer_.data() + i * sliceSize);
+        }
+
+        std::vector<int64_t> inputTensorShape = {
+            static_cast<int64_t>(images.size()), 3, targetSize, targetSize
+        };
+
+        static Ort::MemoryInfo memoryInfo = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+        Ort::Value inputTensor = Ort::Value::CreateTensor<float>(
+            memoryInfo, inputBuffer_.data(), inputBuffer_.size(),
+            inputTensorShape.data(), inputTensorShape.size());
+
+        std::vector<Ort::Value> outputTensors = session_.Run(
+            Ort::RunOptions{nullptr},
+            inputNames_.data(), &inputTensor, numInputNodes_,
+            outputNames_.data(), numOutputNodes_);
+
+        if (outputTensors.empty()) {
+            return std::vector<ClassificationResult>(images.size());
+        }
+
+        const float* rawOutput = outputTensors[0].GetTensorData<float>();
+        const std::vector<int64_t> outputShape = outputTensors[0].GetTensorTypeAndShapeInfo().GetShape();
+        const size_t scoresPerImage = outputShape.size() >= 2
+            ? static_cast<size_t>(outputShape.back())
+            : static_cast<size_t>(numClasses_);
+
+        std::vector<ClassificationResult> results;
+        results.reserve(images.size());
+        for (size_t i = 0; i < images.size(); ++i) {
+            results.push_back(postprocessScores(rawOutput + i * scoresPerImage));
+        }
+
+        return results;
+    }
+
+    void configureSessionOptions(bool useGPU) {
         sessionOptions_ = Ort::SessionOptions();
         sessionOptions_.SetIntraOpNumThreads(std::min(4, static_cast<int>(std::thread::hardware_concurrency())));
         sessionOptions_.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_ALL);
@@ -190,14 +315,11 @@ protected:
         } else {
             std::cout << "[INFO] Classification using CPU" << std::endl;
         }
+    }
 
-#ifdef _WIN32
-        std::wstring wModelPath(modelPath.begin(), modelPath.end());
-        session_ = Ort::Session(env_, wModelPath.c_str(), sessionOptions_);
-#else
-        session_ = Ort::Session(env_, modelPath.c_str(), sessionOptions_);
-#endif
-
+    /// @brief Read node names, shapes and class count from an already-created session
+    /// @param modelLabel Human-readable model identifier used only for logging
+    void introspectSession(const std::string& modelLabel) {
         Ort::AllocatorWithDefaultOptions allocator;
 
         numInputNodes_ = session_.GetInputCount();
@@ -212,6 +334,8 @@ protected:
         std::vector<int64_t> inputShape = inputTypeInfo.GetTensorTypeAndShapeInfo().GetShape();
         if (inputShape.size() == 4) {
             isDynamicInputShape_ = (inputShape[2] == -1 || inputShape[3] == -1);
+            isDynamicBatchSize_ = (inputShape[0] <= 0);
+            modelBatchSize_ = isDynamicBatchSize_ ? -1 : static_cast<int>(inputShape[0]);
             if (!isDynamicInputShape_) {
                 inputImageShape_ = cv::Size(static_cast<int>(inputShape[3]), static_cast<int>(inputShape[2]));
             }
@@ -230,18 +354,32 @@ protected:
             numClasses_ = static_cast<int>(outputShape[0]);
         }
 
-        std::cout << "[INFO] Classification model loaded: " << modelPath << std::endl;
+        std::cout << "[INFO] Classification model loaded: " << modelLabel << std::endl;
         std::cout << "[INFO] Input shape: " << inputImageShape_.width << "x" << inputImageShape_.height << std::endl;
+        std::cout << "[INFO] Batch size: "
+                  << (isDynamicBatchSize_ ? std::string("dynamic") : std::to_string(modelBatchSize_))
+                  << std::endl;
         std::cout << "[INFO] Number of classes: " << numClasses_ << std::endl;
     }
 
-    /// @brief Preprocess image for classification (Ultralytics-style)
+    /// @brief Preprocess image for classification into the shared input buffer
     ///
     /// Mirrors ultralytics.data.augment.classify_transforms(), which is
     ///     T.Resize(size, BILINEAR) -> T.CenterCrop(size) -> T.ToTensor()
     ///       -> T.Normalize(mean=0, std=1)   [a no-op]
-    /// applied to a PIL image.
+    /// applied to a PIL image. The work itself lives in preprocessInto().
     void preprocess(const cv::Mat& image, std::vector<int64_t>& inputTensorShape) {
+        const int targetSize = inputImageShape_.width;
+        inputTensorShape = {1, 3, targetSize, targetSize};
+        inputBuffer_.resize(static_cast<size_t>(3) * targetSize * targetSize);
+        preprocessInto(image, inputBuffer_.data());
+    }
+
+    /// @brief Preprocess image for classification (Ultralytics-style) into a CHW slice
+    /// @param image Input BGR image
+    /// @param dst Destination slice; must hold 3 * targetSize * targetSize floats
+    /// @note Safe to point at one image of a batched N*3*H*W buffer.
+    void preprocessInto(const cv::Mat& image, float* dst) {
         int targetSize = inputImageShape_.width;
         int h = image.rows;
         int w = image.cols;
@@ -277,26 +415,26 @@ protected:
         cv::Mat floatImage;
         cropped.convertTo(floatImage, CV_32F, 1.0 / 255.0);
 
-        inputTensorShape = {1, 3, floatImage.rows, floatImage.cols};
         const int finalH = floatImage.rows;
         const int finalW = floatImage.cols;
-        size_t tensorSize = 3 * finalH * finalW;
-        inputBuffer_.resize(tensorSize);
 
         // Convert HWC to CHW format
         std::vector<cv::Mat> channels(3);
         cv::split(floatImage, channels);
         for (int c = 0; c < 3; ++c) {
-            std::memcpy(inputBuffer_.data() + c * finalH * finalW,
-                       channels[c].ptr<float>(), finalH * finalW * sizeof(float));
+            std::memcpy(dst + static_cast<size_t>(c) * finalH * finalW,
+                       channels[c].ptr<float>(), static_cast<size_t>(finalH) * finalW * sizeof(float));
         }
     }
 
     /// @brief Postprocess classification output
     ClassificationResult postprocess(const std::vector<Ort::Value>& outputTensors) {
-        const float* rawOutput = outputTensors[0].GetTensorData<float>();
-        const std::vector<int64_t> outputShape = outputTensors[0].GetTensorTypeAndShapeInfo().GetShape();
+        return postprocessScores(outputTensors[0].GetTensorData<float>());
+    }
 
+    /// @brief Turn one image's raw score row into a result
+    /// @param rawOutput Pointer to this image's scores (numClasses_ floats)
+    ClassificationResult postprocessScores(const float* rawOutput) {
         int numScores = numClasses_ > 0 ? numClasses_ : static_cast<int>(classNames_.size());
         if (numScores <= 0) return {};
 
@@ -328,6 +466,10 @@ class YOLO11Classifier : public YOLOClassifier {
 public:
     YOLO11Classifier(const std::string& modelPath, const std::string& labelsPath, bool useGPU = false)
         : YOLOClassifier(modelPath, labelsPath, useGPU) {}
+
+    YOLO11Classifier(const void* modelData, size_t modelSize,
+                     const std::vector<std::string>& classNames, bool useGPU = false)
+        : YOLOClassifier(modelData, modelSize, classNames, useGPU) {}
 };
 
 /// @brief YOLOv12 classifier
@@ -335,6 +477,10 @@ class YOLO12Classifier : public YOLOClassifier {
 public:
     YOLO12Classifier(const std::string& modelPath, const std::string& labelsPath, bool useGPU = false)
         : YOLOClassifier(modelPath, labelsPath, useGPU) {}
+
+    YOLO12Classifier(const void* modelData, size_t modelSize,
+                     const std::vector<std::string>& classNames, bool useGPU = false)
+        : YOLOClassifier(modelData, modelSize, classNames, useGPU) {}
 };
 
 /// @brief YOLO26 classifier
@@ -342,6 +488,10 @@ class YOLO26Classifier : public YOLOClassifier {
 public:
     YOLO26Classifier(const std::string& modelPath, const std::string& labelsPath, bool useGPU = false)
         : YOLOClassifier(modelPath, labelsPath, useGPU) {}
+
+    YOLO26Classifier(const void* modelData, size_t modelSize,
+                     const std::vector<std::string>& classNames, bool useGPU = false)
+        : YOLOClassifier(modelData, modelSize, classNames, useGPU) {}
 };
 
 // ============================================================================
@@ -365,6 +515,28 @@ inline std::unique_ptr<YOLOClassifier> createClassifier(const std::string& model
             return std::make_unique<YOLO12Classifier>(modelPath, labelsPath, useGPU);
         default:
             return std::make_unique<YOLO11Classifier>(modelPath, labelsPath, useGPU);
+    }
+}
+
+/// @brief Create a classifier from a model held in memory
+/// @param modelData Pointer to the serialized ONNX model bytes
+/// @param modelSize Size of the buffer in bytes
+/// @param classNames Class names in class-id order
+/// @param version YOLO version
+/// @param useGPU Whether to use GPU
+/// @return Unique pointer to classifier
+inline std::unique_ptr<YOLOClassifier> createClassifierFromMemory(const void* modelData,
+                                                                  size_t modelSize,
+                                                                  const std::vector<std::string>& classNames,
+                                                                  YOLOVersion version = YOLOVersion::V11,
+                                                                  bool useGPU = false) {
+    switch (version) {
+        case YOLOVersion::V26:
+            return std::make_unique<YOLO26Classifier>(modelData, modelSize, classNames, useGPU);
+        case YOLOVersion::V12:
+            return std::make_unique<YOLO12Classifier>(modelData, modelSize, classNames, useGPU);
+        default:
+            return std::make_unique<YOLO11Classifier>(modelData, modelSize, classNames, useGPU);
     }
 }
 

--- a/include/yolos/tasks/detection.hpp
+++ b/include/yolos/tasks/detection.hpp
@@ -61,7 +61,30 @@ public:
           version_(version) {
         classNames_ = utils::getClassNames(labelsPath);
         classColors_ = drawing::generateColors(classNames_);
-        
+
+        // Pre-allocate inference buffer
+        buffer_.ensureCapacity(inputShape_.height, inputShape_.width, inputChannels_);
+    }
+
+    /// @brief Constructor loading the model from memory instead of a file
+    /// @param modelData Pointer to the serialized ONNX model bytes
+    /// @param modelSize Size of the buffer in bytes
+    /// @param classNames Class names in class-id order; when empty, the
+    ///        Ultralytics `names` entry from the ONNX metadata is used
+    /// @param useGPU Whether to use GPU for inference
+    /// @param version YOLO version (Auto for runtime detection)
+    /// @note ONNX Runtime copies the buffer during session creation, so
+    ///       @p modelData may be freed once the constructor returns.
+    YOLODetector(const void* modelData,
+                 size_t modelSize,
+                 const std::vector<std::string>& classNames,
+                 bool useGPU = false,
+                 YOLOVersion version = YOLOVersion::Auto)
+        : OrtSessionBase(modelData, modelSize, useGPU),
+          version_(version) {
+        classNames_ = classNames.empty() ? getExportedClassNamesFromMetadata() : classNames;
+        classColors_ = drawing::generateColors(classNames_);
+
         // Pre-allocate inference buffer
         buffer_.ensureCapacity(inputShape_.height, inputShape_.width, inputChannels_);
     }
@@ -95,6 +118,43 @@ public:
 
         // Postprocess based on version
         return postprocess(image.size(), actualSize, outputTensors, effectiveVersion, confThreshold, iouThreshold);
+    }
+
+    /// @brief Run detection on several images with a single ONNX Runtime call
+    /// @param images Input images (BGR format)
+    /// @param confThreshold Confidence threshold
+    /// @param iouThreshold IoU threshold for NMS
+    /// @return One detection vector per input image, in input order
+    /// @note Packs the batch into one N*C*H*W tensor when the model accepts the
+    ///       batch size (dynamic batch dimension, or a fixed one that matches
+    ///       images.size()), which is what improves GPU throughput. Otherwise it
+    ///       falls back to calling detect() per image, so the results are always
+    ///       produced regardless of how the model was exported.
+    /// @note Batched runs letterbox every image to the model input shape, so a
+    ///       dynamic-input-shape model can return slightly different boxes than
+    ///       detect(), which picks a per-image stride-aligned shape.
+    virtual std::vector<std::vector<Detection>> batchDetect(const std::vector<cv::Mat>& images,
+                                                            float confThreshold = 0.4f,
+                                                            float iouThreshold = 0.45f) {
+        std::vector<std::vector<Detection>> results;
+        if (images.empty()) return results;
+
+        if (supportsBatchSize(images.size()) && allOutputsAreFloat()) {
+            try {
+                return batchDetectPacked(images, confThreshold, iouThreshold);
+            } catch (const Ort::Exception& e) {
+                // Some exports declare a dynamic batch dimension the graph cannot
+                // actually run (hard-coded Reshape targets, for instance).
+                std::cerr << "[WARNING] Batched inference failed (" << e.what()
+                          << "). Falling back to per-image inference." << std::endl;
+            }
+        }
+
+        results.reserve(images.size());
+        for (const auto& image : images) {
+            results.push_back(detect(image, confThreshold, iouThreshold));
+        }
+        return results;
     }
 
     /// @brief Draw detections on an image
@@ -144,6 +204,37 @@ protected:
     
     // Pre-allocated buffer for inference (avoids per-frame allocations)
     mutable preprocessing::InferenceBuffer buffer_;
+
+    // Pre-allocated N*C*H*W buffer reused across batchDetect() calls
+    std::vector<float> batchBlob_;
+
+    /// @brief Single batched ONNX call plus per-image postprocessing
+    /// Throws Ort::Exception if the model cannot run the requested batch size.
+    std::vector<std::vector<Detection>> batchDetectPacked(const std::vector<cv::Mat>& images,
+                                                          float confThreshold,
+                                                          float iouThreshold) {
+        const int64_t batchSize = static_cast<int64_t>(images.size());
+
+        cv::Size letterboxSize;
+        std::vector<Ort::Value> outputTensors = runBatchInference(images, batchBlob_, letterboxSize);
+
+        // Determine version once from the batched output shape
+        YOLOVersion effectiveVersion = version_;
+        if (effectiveVersion == YOLOVersion::Auto) {
+            effectiveVersion = detectVersion(outputTensors);
+        }
+
+        std::vector<std::vector<Detection>> results;
+        results.reserve(images.size());
+        for (int64_t i = 0; i < batchSize; ++i) {
+            // Zero-copy [1, ...] views so the regular postprocessing runs unchanged
+            std::vector<Ort::Value> itemTensors = sliceOutputBatch(outputTensors, i, batchSize);
+            results.push_back(postprocess(images[static_cast<size_t>(i)].size(), letterboxSize,
+                                          itemTensors, effectiveVersion, confThreshold, iouThreshold));
+        }
+
+        return results;
+    }
 
     /// @brief Detect YOLO version from output tensors
     YOLOVersion detectVersion(const std::vector<Ort::Value>& outputTensors) {
@@ -457,6 +548,10 @@ class YOLOv7Detector : public YOLODetector {
 public:
     YOLOv7Detector(const std::string& modelPath, const std::string& labelsPath, bool useGPU = false)
         : YOLODetector(modelPath, labelsPath, useGPU, YOLOVersion::V7) {}
+
+    YOLOv7Detector(const void* modelData, size_t modelSize,
+                   const std::vector<std::string>& classNames, bool useGPU = false)
+        : YOLODetector(modelData, modelSize, classNames, useGPU, YOLOVersion::V7) {}
 };
 
 /// @brief YOLOv8 detector (forces standard postprocessing)
@@ -464,6 +559,10 @@ class YOLOv8Detector : public YOLODetector {
 public:
     YOLOv8Detector(const std::string& modelPath, const std::string& labelsPath, bool useGPU = false)
         : YOLODetector(modelPath, labelsPath, useGPU, YOLOVersion::V8) {}
+
+    YOLOv8Detector(const void* modelData, size_t modelSize,
+                   const std::vector<std::string>& classNames, bool useGPU = false)
+        : YOLODetector(modelData, modelSize, classNames, useGPU, YOLOVersion::V8) {}
 };
 
 /// @brief YOLOv10 detector (forces V10 end-to-end postprocessing)
@@ -471,6 +570,10 @@ class YOLOv10Detector : public YOLODetector {
 public:
     YOLOv10Detector(const std::string& modelPath, const std::string& labelsPath, bool useGPU = false)
         : YOLODetector(modelPath, labelsPath, useGPU, YOLOVersion::V10) {}
+
+    YOLOv10Detector(const void* modelData, size_t modelSize,
+                    const std::vector<std::string>& classNames, bool useGPU = false)
+        : YOLODetector(modelData, modelSize, classNames, useGPU, YOLOVersion::V10) {}
 };
 
 /// @brief YOLOv11 detector (forces standard postprocessing)
@@ -478,6 +581,10 @@ class YOLOv11Detector : public YOLODetector {
 public:
     YOLOv11Detector(const std::string& modelPath, const std::string& labelsPath, bool useGPU = false)
         : YOLODetector(modelPath, labelsPath, useGPU, YOLOVersion::V11) {}
+
+    YOLOv11Detector(const void* modelData, size_t modelSize,
+                    const std::vector<std::string>& classNames, bool useGPU = false)
+        : YOLODetector(modelData, modelSize, classNames, useGPU, YOLOVersion::V11) {}
 };
 
 /// @brief YOLO-NAS detector (forces NAS postprocessing)
@@ -485,6 +592,10 @@ class YOLONASDetector : public YOLODetector {
 public:
     YOLONASDetector(const std::string& modelPath, const std::string& labelsPath, bool useGPU = false)
         : YOLODetector(modelPath, labelsPath, useGPU, YOLOVersion::NAS) {}
+
+    YOLONASDetector(const void* modelData, size_t modelSize,
+                    const std::vector<std::string>& classNames, bool useGPU = false)
+        : YOLODetector(modelData, modelSize, classNames, useGPU, YOLOVersion::NAS) {}
 };
 
 /// @brief YOLOv26 detector (forces V26 end-to-end postprocessing)
@@ -492,6 +603,10 @@ class YOLO26Detector : public YOLODetector {
 public:
     YOLO26Detector(const std::string& modelPath, const std::string& labelsPath, bool useGPU = false)
         : YOLODetector(modelPath, labelsPath, useGPU, YOLOVersion::V26) {}
+
+    YOLO26Detector(const void* modelData, size_t modelSize,
+                   const std::vector<std::string>& classNames, bool useGPU = false)
+        : YOLODetector(modelData, modelSize, classNames, useGPU, YOLOVersion::V26) {}
 };
 
 // ============================================================================
@@ -523,6 +638,36 @@ inline std::unique_ptr<YOLODetector> createDetector(const std::string& modelPath
             return std::make_unique<YOLONASDetector>(modelPath, labelsPath, useGPU);
         default:
             return std::make_unique<YOLODetector>(modelPath, labelsPath, useGPU, YOLOVersion::Auto);
+    }
+}
+
+/// @brief Create a detector from a model held in memory
+/// @param modelData Pointer to the serialized ONNX model bytes
+/// @param modelSize Size of the buffer in bytes
+/// @param classNames Class names in class-id order (empty = read ONNX metadata)
+/// @param version YOLO version (Auto for runtime detection)
+/// @param useGPU Whether to use GPU
+/// @return Unique pointer to detector
+inline std::unique_ptr<YOLODetector> createDetectorFromMemory(const void* modelData,
+                                                              size_t modelSize,
+                                                              const std::vector<std::string>& classNames,
+                                                              YOLOVersion version = YOLOVersion::Auto,
+                                                              bool useGPU = false) {
+    switch (version) {
+        case YOLOVersion::V7:
+            return std::make_unique<YOLOv7Detector>(modelData, modelSize, classNames, useGPU);
+        case YOLOVersion::V8:
+            return std::make_unique<YOLOv8Detector>(modelData, modelSize, classNames, useGPU);
+        case YOLOVersion::V10:
+            return std::make_unique<YOLOv10Detector>(modelData, modelSize, classNames, useGPU);
+        case YOLOVersion::V11:
+            return std::make_unique<YOLOv11Detector>(modelData, modelSize, classNames, useGPU);
+        case YOLOVersion::V26:
+            return std::make_unique<YOLO26Detector>(modelData, modelSize, classNames, useGPU);
+        case YOLOVersion::NAS:
+            return std::make_unique<YOLONASDetector>(modelData, modelSize, classNames, useGPU);
+        default:
+            return std::make_unique<YOLODetector>(modelData, modelSize, classNames, useGPU, YOLOVersion::Auto);
     }
 }
 

--- a/include/yolos/tasks/obb.hpp
+++ b/include/yolos/tasks/obb.hpp
@@ -64,7 +64,27 @@ public:
         : OrtSessionBase(modelPath, useGPU) {
         classNames_ = utils::getClassNames(labelsPath);
         classColors_ = drawing::generateColors(classNames_);
-        
+
+        // Pre-allocate inference buffer
+        buffer_.ensureCapacity(inputShape_.height, inputShape_.width, inputChannels_);
+    }
+
+    /// @brief Constructor loading the model from memory instead of a file
+    /// @param modelData Pointer to the serialized ONNX model bytes
+    /// @param modelSize Size of the buffer in bytes
+    /// @param classNames Class names in class-id order; when empty, the
+    ///        Ultralytics `names` entry from the ONNX metadata is used
+    /// @param useGPU Whether to use GPU for inference
+    /// @note ONNX Runtime copies the buffer during session creation, so
+    ///       @p modelData may be freed once the constructor returns.
+    YOLOOBBDetector(const void* modelData,
+                    size_t modelSize,
+                    const std::vector<std::string>& classNames,
+                    bool useGPU = false)
+        : OrtSessionBase(modelData, modelSize, useGPU) {
+        classNames_ = classNames.empty() ? getExportedClassNamesFromMetadata() : classNames;
+        classColors_ = drawing::generateColors(classNames_);
+
         // Pre-allocate inference buffer
         buffer_.ensureCapacity(inputShape_.height, inputShape_.width, inputChannels_);
     }
@@ -96,6 +116,43 @@ public:
         return postprocess(image.size(), actualSize, outputTensors, confThreshold, iouThreshold, maxDet);
     }
 
+    /// @brief Run OBB detection on several images with a single ONNX Runtime call
+    /// @param images Input images (BGR format)
+    /// @param confThreshold Confidence threshold
+    /// @param iouThreshold IoU threshold for NMS
+    /// @param maxDet Maximum number of detections to return per image
+    /// @return One OBB-result vector per input image, in input order
+    /// @note Packs the batch into one N*C*H*W tensor when the model accepts the
+    ///       batch size (dynamic batch dimension, or a fixed one that matches
+    ///       images.size()); otherwise falls back to detect() per image.
+    /// @note Batched runs letterbox every image to the model input shape, so a
+    ///       dynamic-input-shape model can return slightly different boxes than
+    ///       detect(), which picks a per-image stride-aligned shape.
+    virtual std::vector<std::vector<OBBResult>> batchDetect(const std::vector<cv::Mat>& images,
+                                                            float confThreshold = 0.25f,
+                                                            float iouThreshold = 0.45f,
+                                                            int maxDet = 300) {
+        std::vector<std::vector<OBBResult>> results;
+        if (images.empty()) return results;
+
+        if (supportsBatchSize(images.size()) && allOutputsAreFloat()) {
+            try {
+                return batchDetectPacked(images, confThreshold, iouThreshold, maxDet);
+            } catch (const Ort::Exception& e) {
+                // Some exports declare a dynamic batch dimension the graph cannot
+                // actually run (hard-coded Reshape targets, for instance).
+                std::cerr << "[WARNING] Batched inference failed (" << e.what()
+                          << "). Falling back to per-image inference." << std::endl;
+            }
+        }
+
+        results.reserve(images.size());
+        for (const auto& image : images) {
+            results.push_back(detect(image, confThreshold, iouThreshold, maxDet));
+        }
+        return results;
+    }
+
     /// @brief Draw OBB detections on an image
     /// @param image Image to draw on
     /// @param results Vector of OBB detection results
@@ -125,6 +182,32 @@ protected:
     
     // Pre-allocated buffer for inference
     mutable preprocessing::InferenceBuffer buffer_;
+
+    // Pre-allocated N*C*H*W buffer reused across batchDetect() calls
+    std::vector<float> batchBlob_;
+
+    /// @brief Single batched ONNX call plus per-image postprocessing
+    /// Throws Ort::Exception if the model cannot run the requested batch size.
+    std::vector<std::vector<OBBResult>> batchDetectPacked(const std::vector<cv::Mat>& images,
+                                                          float confThreshold,
+                                                          float iouThreshold,
+                                                          int maxDet) {
+        const int64_t batchSize = static_cast<int64_t>(images.size());
+
+        cv::Size letterboxSize;
+        std::vector<Ort::Value> outputTensors = runBatchInference(images, batchBlob_, letterboxSize);
+
+        std::vector<std::vector<OBBResult>> results;
+        results.reserve(images.size());
+        for (int64_t i = 0; i < batchSize; ++i) {
+            // Zero-copy [1, ...] views so the regular postprocessing runs unchanged
+            std::vector<Ort::Value> itemTensors = sliceOutputBatch(outputTensors, i, batchSize);
+            results.push_back(postprocess(images[static_cast<size_t>(i)].size(), letterboxSize,
+                                          itemTensors, confThreshold, iouThreshold, maxDet));
+        }
+
+        return results;
+    }
 
     /// @brief Postprocess OBB detection outputs
     std::vector<OBBResult> postprocess(const cv::Size& originalSize,

--- a/include/yolos/tasks/pose.hpp
+++ b/include/yolos/tasks/pose.hpp
@@ -66,7 +66,34 @@ public:
             classNames_ = {"person"};
         }
         classColors_ = drawing::generateColors(classNames_);
-        
+
+        // Pre-allocate inference buffer
+        buffer_.ensureCapacity(inputShape_.height, inputShape_.width, inputChannels_);
+    }
+
+    /// @brief Constructor loading the model from memory instead of a file
+    /// @param modelData Pointer to the serialized ONNX model bytes
+    /// @param modelSize Size of the buffer in bytes
+    /// @param classNames Class names in class-id order; when empty, the ONNX
+    ///        metadata names are used, falling back to {"person"}
+    /// @param useGPU Whether to use GPU for inference
+    /// @note ONNX Runtime copies the buffer during session creation, so
+    ///       @p modelData may be freed once the constructor returns.
+    YOLOPoseDetector(const void* modelData,
+                     size_t modelSize,
+                     const std::vector<std::string>& classNames = {},
+                     bool useGPU = false)
+        : OrtSessionBase(modelData, modelSize, useGPU) {
+
+        if (!classNames.empty()) {
+            classNames_ = classNames;
+        } else if (!getExportedClassNamesFromMetadata().empty()) {
+            classNames_ = getExportedClassNamesFromMetadata();
+        } else {
+            classNames_ = {"person"};
+        }
+        classColors_ = drawing::generateColors(classNames_);
+
         // Pre-allocate inference buffer
         buffer_.ensureCapacity(inputShape_.height, inputShape_.width, inputChannels_);
     }
@@ -94,6 +121,41 @@ public:
 
         // Postprocess
         return postprocess(image.size(), actualSize, outputTensors, confThreshold, iouThreshold);
+    }
+
+    /// @brief Run pose detection on several images with a single ONNX Runtime call
+    /// @param images Input images (BGR format)
+    /// @param confThreshold Confidence threshold
+    /// @param iouThreshold IoU threshold for NMS
+    /// @return One pose-result vector per input image, in input order
+    /// @note Packs the batch into one N*C*H*W tensor when the model accepts the
+    ///       batch size (dynamic batch dimension, or a fixed one that matches
+    ///       images.size()); otherwise falls back to detect() per image.
+    /// @note Batched runs letterbox every image to the model input shape, so a
+    ///       dynamic-input-shape model can return slightly different keypoints
+    ///       than detect(), which picks a per-image stride-aligned shape.
+    virtual std::vector<std::vector<PoseResult>> batchDetect(const std::vector<cv::Mat>& images,
+                                                             float confThreshold = 0.4f,
+                                                             float iouThreshold = 0.5f) {
+        std::vector<std::vector<PoseResult>> results;
+        if (images.empty()) return results;
+
+        if (supportsBatchSize(images.size()) && allOutputsAreFloat()) {
+            try {
+                return batchDetectPacked(images, confThreshold, iouThreshold);
+            } catch (const Ort::Exception& e) {
+                // Some exports declare a dynamic batch dimension the graph cannot
+                // actually run (hard-coded Reshape targets, for instance).
+                std::cerr << "[WARNING] Batched inference failed (" << e.what()
+                          << "). Falling back to per-image inference." << std::endl;
+            }
+        }
+
+        results.reserve(images.size());
+        for (const auto& image : images) {
+            results.push_back(detect(image, confThreshold, iouThreshold));
+        }
+        return results;
     }
 
     /// @brief Draw pose estimations on an image
@@ -156,6 +218,31 @@ protected:
     
     // Pre-allocated buffer for inference
     mutable preprocessing::InferenceBuffer buffer_;
+
+    // Pre-allocated N*C*H*W buffer reused across batchDetect() calls
+    std::vector<float> batchBlob_;
+
+    /// @brief Single batched ONNX call plus per-image postprocessing
+    /// Throws Ort::Exception if the model cannot run the requested batch size.
+    std::vector<std::vector<PoseResult>> batchDetectPacked(const std::vector<cv::Mat>& images,
+                                                           float confThreshold,
+                                                           float iouThreshold) {
+        const int64_t batchSize = static_cast<int64_t>(images.size());
+
+        cv::Size letterboxSize;
+        std::vector<Ort::Value> outputTensors = runBatchInference(images, batchBlob_, letterboxSize);
+
+        std::vector<std::vector<PoseResult>> results;
+        results.reserve(images.size());
+        for (int64_t i = 0; i < batchSize; ++i) {
+            // Zero-copy [1, ...] views so the regular postprocessing runs unchanged
+            std::vector<Ort::Value> itemTensors = sliceOutputBatch(outputTensors, i, batchSize);
+            results.push_back(postprocess(images[static_cast<size_t>(i)].size(), letterboxSize,
+                                          itemTensors, confThreshold, iouThreshold));
+        }
+
+        return results;
+    }
 
     /// @brief Postprocess pose detection outputs
     std::vector<PoseResult> postprocess(const cv::Size& originalSize,

--- a/include/yolos/tasks/segmentation.hpp
+++ b/include/yolos/tasks/segmentation.hpp
@@ -66,7 +66,33 @@ public:
         
         classNames_ = utils::getClassNames(labelsPath);
         classColors_ = drawing::generateColors(classNames_);
-        
+
+        // Pre-allocate inference buffer
+        buffer_.ensureCapacity(inputShape_.height, inputShape_.width, inputChannels_);
+    }
+
+    /// @brief Constructor loading the model from memory instead of a file
+    /// @param modelData Pointer to the serialized ONNX model bytes
+    /// @param modelSize Size of the buffer in bytes
+    /// @param classNames Class names in class-id order; when empty, the
+    ///        Ultralytics `names` entry from the ONNX metadata is used
+    /// @param useGPU Whether to use GPU for inference
+    /// @note ONNX Runtime copies the buffer during session creation, so
+    ///       @p modelData may be freed once the constructor returns.
+    YOLOSegDetector(const void* modelData,
+                    size_t modelSize,
+                    const std::vector<std::string>& classNames,
+                    bool useGPU = false)
+        : OrtSessionBase(modelData, modelSize, useGPU) {
+
+        // Validate output count for segmentation models
+        if (numOutputNodes_ != 2) {
+            throw std::runtime_error("Expected 2 output nodes for segmentation model (output0 and output1)");
+        }
+
+        classNames_ = classNames.empty() ? getExportedClassNamesFromMetadata() : classNames;
+        classColors_ = drawing::generateColors(classNames_);
+
         // Pre-allocate inference buffer
         buffer_.ensureCapacity(inputShape_.height, inputShape_.width, inputChannels_);
     }
@@ -94,6 +120,41 @@ public:
 
         // Postprocess
         return postprocess(image.size(), actualSize, outputTensors, confThreshold, iouThreshold);
+    }
+
+    /// @brief Run segmentation on several images with a single ONNX Runtime call
+    /// @param images Input images (BGR format)
+    /// @param confThreshold Confidence threshold
+    /// @param iouThreshold IoU threshold for NMS
+    /// @return One segmentation vector per input image, in input order
+    /// @note Packs the batch into one N*C*H*W tensor when the model accepts the
+    ///       batch size (dynamic batch dimension, or a fixed one that matches
+    ///       images.size()); otherwise falls back to segment() per image.
+    /// @note Batched runs letterbox every image to the model input shape, so a
+    ///       dynamic-input-shape model can return slightly different masks than
+    ///       segment(), which picks a per-image stride-aligned shape.
+    virtual std::vector<std::vector<Segmentation>> batchSegment(const std::vector<cv::Mat>& images,
+                                                                float confThreshold = 0.4f,
+                                                                float iouThreshold = 0.45f) {
+        std::vector<std::vector<Segmentation>> results;
+        if (images.empty()) return results;
+
+        if (supportsBatchSize(images.size()) && allOutputsAreFloat()) {
+            try {
+                return batchSegmentPacked(images, confThreshold, iouThreshold);
+            } catch (const Ort::Exception& e) {
+                // Some exports declare a dynamic batch dimension the graph cannot
+                // actually run (hard-coded Reshape targets, for instance).
+                std::cerr << "[WARNING] Batched inference failed (" << e.what()
+                          << "). Falling back to per-image inference." << std::endl;
+            }
+        }
+
+        results.reserve(images.size());
+        for (const auto& image : images) {
+            results.push_back(segment(image, confThreshold, iouThreshold));
+        }
+        return results;
     }
 
     /// @brief Draw segmentations with boxes and labels on an image
@@ -158,6 +219,32 @@ protected:
     
     // Pre-allocated buffer for inference (avoids per-frame allocations)
     mutable preprocessing::InferenceBuffer buffer_;
+
+    // Pre-allocated N*C*H*W buffer reused across batchSegment() calls
+    std::vector<float> batchBlob_;
+
+    /// @brief Single batched ONNX call plus per-image postprocessing
+    /// Throws Ort::Exception if the model cannot run the requested batch size.
+    std::vector<std::vector<Segmentation>> batchSegmentPacked(const std::vector<cv::Mat>& images,
+                                                             float confThreshold,
+                                                             float iouThreshold) {
+        const int64_t batchSize = static_cast<int64_t>(images.size());
+
+        cv::Size letterboxSize;
+        std::vector<Ort::Value> outputTensors = runBatchInference(images, batchBlob_, letterboxSize);
+
+        std::vector<std::vector<Segmentation>> results;
+        results.reserve(images.size());
+        for (int64_t i = 0; i < batchSize; ++i) {
+            // Zero-copy [1, ...] views (detections and mask prototypes) so the
+            // regular postprocessing runs unchanged
+            std::vector<Ort::Value> itemTensors = sliceOutputBatch(outputTensors, i, batchSize);
+            results.push_back(postprocess(images[static_cast<size_t>(i)].size(), letterboxSize,
+                                          itemTensors, confThreshold, iouThreshold));
+        }
+
+        return results;
+    }
 
     /// @brief Postprocess segmentation outputs
     std::vector<Segmentation> postprocess(const cv::Size& originalSize,

--- a/include/yolos/tasks/yoloe.hpp
+++ b/include/yolos/tasks/yoloe.hpp
@@ -114,6 +114,28 @@ public:
         agnosticNms_ = agnosticNms;
     }
 
+    /// @brief Construct from a model held in memory plus inline class names
+    /// @param modelData Pointer to the serialized ONNX model bytes
+    /// @param modelSize Size of the buffer in bytes
+    /// @param classNames Class names that were used during model.set_classes() in Python
+    /// @param useGPU Whether to use CUDA GPU for inference
+    /// @param agnosticNms Use class-agnostic NMS (recommended; suppresses across classes)
+    /// @note ONNX Runtime copies the buffer during session creation, so
+    ///       @p modelData may be freed once the constructor returns.
+    YOLOEDetector(const void* modelData,
+                  size_t modelSize,
+                  const std::vector<std::string>& classNames,
+                  bool useGPU = false,
+                  bool agnosticNms = true)
+        : det::YOLODetector(modelData, modelSize, classNames, useGPU, YOLOVersion::Auto)
+    {
+        if (classNames.empty()) {
+            throw std::invalid_argument("YOLOEDetector: classNames must not be empty");
+        }
+        detail::validateInlineClassesMatchOnnxExport(classNames, getExportedClassNamesFromMetadata());
+        agnosticNms_ = agnosticNms;
+    }
+
     virtual ~YOLOEDetector() = default;
 
     /// @brief Relabel fixed output channels without reloading the model.
@@ -176,6 +198,28 @@ public:
                      bool agnosticNms = true)
         : seg::YOLOSegDetector(modelPath, labelsPath, useGPU)
     {
+        agnosticNms_ = agnosticNms;
+    }
+
+    /// @brief Construct from a model held in memory plus inline class names
+    /// @param modelData Pointer to the serialized ONNX model bytes
+    /// @param modelSize Size of the buffer in bytes
+    /// @param classNames Class names that were used during model.set_classes() in Python
+    /// @param useGPU Whether to use CUDA GPU for inference
+    /// @param agnosticNms Use class-agnostic NMS (recommended; suppresses across classes)
+    /// @note ONNX Runtime copies the buffer during session creation, so
+    ///       @p modelData may be freed once the constructor returns.
+    YOLOESegDetector(const void* modelData,
+                     size_t modelSize,
+                     const std::vector<std::string>& classNames,
+                     bool useGPU = false,
+                     bool agnosticNms = true)
+        : seg::YOLOSegDetector(modelData, modelSize, classNames, useGPU)
+    {
+        if (classNames.empty()) {
+            throw std::invalid_argument("YOLOESegDetector: classNames must not be empty");
+        }
+        detail::validateInlineClassesMatchOnnxExport(classNames, getExportedClassNamesFromMetadata());
         agnosticNms_ = agnosticNms;
     }
 
@@ -257,6 +301,40 @@ inline std::unique_ptr<YOLOESegDetector> createYOLOESegDetector(
     bool agnosticNms = true)
 {
     return std::make_unique<YOLOESegDetector>(modelPath, labelsPath, useGPU, agnosticNms);
+}
+
+/// @brief Create a YOLOE open-vocabulary detector from a model held in memory.
+/// @param modelData Pointer to the serialized ONNX model bytes
+/// @param modelSize Size of the buffer in bytes
+/// @param classNames Class names used when exporting the model
+/// @param useGPU Whether to use CUDA GPU
+/// @param agnosticNms Use class-agnostic NMS (default true)
+/// @return Unique pointer to YOLOEDetector
+inline std::unique_ptr<YOLOEDetector> createYOLOEDetectorFromMemory(
+    const void* modelData,
+    size_t modelSize,
+    const std::vector<std::string>& classNames,
+    bool useGPU = false,
+    bool agnosticNms = true)
+{
+    return std::make_unique<YOLOEDetector>(modelData, modelSize, classNames, useGPU, agnosticNms);
+}
+
+/// @brief Create a YOLOE open-vocabulary segmentation detector from a model held in memory.
+/// @param modelData Pointer to the serialized ONNX model bytes
+/// @param modelSize Size of the buffer in bytes
+/// @param classNames Class names used when exporting the model
+/// @param useGPU Whether to use CUDA GPU
+/// @param agnosticNms Use class-agnostic NMS (default true)
+/// @return Unique pointer to YOLOESegDetector
+inline std::unique_ptr<YOLOESegDetector> createYOLOESegDetectorFromMemory(
+    const void* modelData,
+    size_t modelSize,
+    const std::vector<std::string>& classNames,
+    bool useGPU = false,
+    bool agnosticNms = true)
+{
+    return std::make_unique<YOLOESegDetector>(modelData, modelSize, classNames, useGPU, agnosticNms);
 }
 
 } // namespace yoloe

--- a/src/batch_image_inference.cpp
+++ b/src/batch_image_inference.cpp
@@ -1,9 +1,15 @@
 /**
  * @file batch_image_inference.cpp
  * @brief Batch object detection on multiple images using YOLO models (v5, v7, v8, v9, v10, v11, v12).
- * 
- * This file implements batch object detection that utilizes YOLO models with dynamic batch input support.
- * The application loads multiple images, processes them in batch, and displays the results with bounding boxes.
+ *
+ * Packs every image into a single ONNX Runtime call via YOLODetector::batchDetect(),
+ * which is where the GPU throughput win comes from. Models exported with a fixed
+ * batch dimension fall back to a per-image loop automatically, so this works with
+ * any export; use `model.export(format="onnx", dynamic=True)` for the batched path.
+ *
+ * Also demonstrates in-memory model loading (`--in-memory`): the ONNX bytes are
+ * read into a buffer and handed to the detector directly, for encrypted stores,
+ * network streams or resources embedded in the binary.
  *
  * Usage Instructions:
  * 1. Compile the application with the necessary OpenCV and YOLO dependencies.
@@ -15,105 +21,147 @@
  */
 
 #include <opencv2/highgui/highgui.hpp>
-#include <iostream>
-#include <string>
+#include <algorithm>
 #include <chrono>
 #include <filesystem>
-#include <algorithm>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "yolos/tasks/detection.hpp"
 
 using namespace yolos::det;
 
-int main(int argc, char* argv[]){
-    namespace fs = std::filesystem;
+namespace {
+
+namespace fs = std::filesystem;
+
+bool isImageFile(const fs::path& path) {
+    std::string ext = path.extension().string();
+    std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+    return ext == ".jpg" || ext == ".jpeg" || ext == ".png" ||
+           ext == ".bmp" || ext == ".tiff" || ext == ".tif";
+}
+
+std::vector<std::string> collectImageFiles(const std::string& imagePath) {
+    std::vector<std::string> imageFiles;
+
+    if (fs::is_directory(imagePath)) {
+        for (const auto& entry : fs::directory_iterator(imagePath)) {
+            if (entry.is_regular_file() && isImageFile(entry.path())) {
+                imageFiles.push_back(fs::absolute(entry.path()).string());
+            }
+        }
+        std::sort(imageFiles.begin(), imageFiles.end());
+    } else if (fs::is_regular_file(imagePath)) {
+        imageFiles.push_back(imagePath);
+    }
+
+    return imageFiles;
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
     std::string labelsPath = "../models/coco.names";
     std::string imagePath = "../data/";
     std::string modelPath = "../models/yolo11n.onnx";
-    std::vector<std::string> imageFiles;
+    bool loadFromMemory = false;
+    bool showWindows = true;
 
-    if(argc > 1){
-        modelPath = argv[1];
-    }
-    if(argc > 2){
-        imagePath = argv[2];
-        if(fs::is_directory(imagePath)){
-            for(const auto& entry : fs::directory_iterator(imagePath)){
-                if(entry.is_regular_file()){
-                    std::string ext = entry.path().extension().string();
-                    std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
-                    if(ext == ".jpg" || ext == ".jpeg" || ext == ".png" || ext == ".bmp" || ext == ".tiff" || ext == ".tif"){
-                        imageFiles.push_back(fs::absolute(entry.path()).string());
-                    }
-                }
-            }
-            if(imageFiles.empty()){
-                std::cerr << "No image files found in directory: " << imagePath << std::endl;
-                return -1;
-            }
-        } else if(fs::is_regular_file(imagePath)){
-            imageFiles.push_back(imagePath);
+    std::vector<std::string> positional;
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "--in-memory") {
+            loadFromMemory = true;
+        } else if (arg == "--no-display") {
+            showWindows = false;
+        } else if (arg == "-h" || arg == "--help") {
+            std::cout << "Usage: " << argv[0]
+                      << " [model_path] [image_path_or_folder] [labels_path] [--in-memory] [--no-display]\n";
+            return 0;
         } else {
-            std::cerr << "Provided path is not a valid file or directory: " << imagePath << std::endl;
-            return -1;
-        }
-    } else {
-        std::cout << "Usage: " << argv[0] << " <model_path> <image_path_or_folder> [labels_path]\n";
-        std::cout << "No image path provided. Using default directory: " << imagePath << std::endl;
-        for(const auto& entry : fs::directory_iterator(imagePath)){
-            if(entry.is_regular_file()){
-                std::string ext = entry.path().extension().string();
-                std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
-                if(ext == ".jpg" || ext == ".jpeg" || ext == ".png" || ext == ".bmp" || ext == ".tiff" || ext == ".tif"){
-                    imageFiles.push_back(fs::absolute(entry.path()).string());
-                }
-            }
-        }
-        if(imageFiles.empty()){
-            std::cerr << "No image files found in default directory: " << imagePath << std::endl;
-            return -1;
+            positional.push_back(arg);
         }
     }
-    if(argc > 3){
-        labelsPath = argv[3];
+
+    if (positional.size() > 0) modelPath = positional[0];
+    if (positional.size() > 1) imagePath = positional[1];
+    if (positional.size() > 2) labelsPath = positional[2];
+
+    if (positional.empty()) {
+        std::cout << "Usage: " << argv[0]
+                  << " [model_path] [image_path_or_folder] [labels_path] [--in-memory] [--no-display]\n";
+        std::cout << "No model path provided. Using defaults: " << modelPath << ", " << imagePath << std::endl;
+    }
+
+    const std::vector<std::string> imageFiles = collectImageFiles(imagePath);
+    if (imageFiles.empty()) {
+        std::cerr << "No image files found at: " << imagePath << std::endl;
+        return -1;
     }
 
     // Load all images
     std::vector<cv::Mat> images;
-    for(const auto& imgPath : imageFiles){
+    std::vector<std::string> loadedFiles;
+    images.reserve(imageFiles.size());
+    for (const auto& imgPath : imageFiles) {
         cv::Mat img = cv::imread(imgPath);
-        if(img.empty()){
+        if (img.empty()) {
             std::cerr << "Warning: Could not open or find image: " << imgPath << std::endl;
             continue;
         }
         images.push_back(img);
+        loadedFiles.push_back(imgPath);
     }
-    if(images.empty()){
+    if (images.empty()) {
         std::cerr << "No valid images to process." << std::endl;
         return -1;
     }
 
-    bool isGPU = true; // Set to false for CPU processing
-    YOLODetector detector(modelPath, labelsPath, isGPU);
+    const bool isGPU = true; // Set to false for CPU processing
 
-    // Process all images
-    std::vector<std::vector<Detection>> allResults;
-    allResults.reserve(images.size());
+    std::unique_ptr<YOLODetector> detector;
+    if (loadFromMemory) {
+        // Stand-in for an encrypted store, a network stream or an embedded resource:
+        // whatever produces the bytes, only the buffer reaches the detector.
+        const std::vector<uint8_t> modelBytes = yolos::utils::readFileBytes(modelPath);
+        if (modelBytes.empty()) {
+            std::cerr << "Failed to read model into memory: " << modelPath << std::endl;
+            return -1;
+        }
+        std::cout << "[INFO] Loading model from memory (" << modelBytes.size() << " bytes)" << std::endl;
 
-    auto start = std::chrono::high_resolution_clock::now();
-    for(size_t i = 0; i < images.size(); ++i){
-        std::cout << "Processing image " << (i + 1) << "/" << images.size() 
-                  << " size: " << images[i].size() << std::endl;
-        std::vector<Detection> results = detector.detect(images[i], 0.45f);
-        allResults.push_back(results);
+        // Class names come in as a vector, so no labels file is needed either.
+        const std::vector<std::string> classNames = yolos::utils::getClassNames(labelsPath);
+        detector = std::make_unique<YOLODetector>(modelBytes.data(), modelBytes.size(), classNames, isGPU);
+        // modelBytes may go out of scope here: ONNX Runtime copied it during session creation.
+    } else {
+        detector = std::make_unique<YOLODetector>(modelPath, labelsPath, isGPU);
     }
-    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
-                        std::chrono::high_resolution_clock::now() - start);
-    std::cout << "Detection completed in: " << duration.count() << " ms" << std::endl;
 
-    for(size_t i = 0; i < allResults.size(); ++i){
-        std::cout << "\nImage: " << imageFiles[i] << std::endl;
+    if (detector->supportsBatchSize(images.size())) {
+        std::cout << "[INFO] Running a single batched inference over " << images.size()
+                  << " image(s)" << std::endl;
+    } else {
+        std::cout << "[INFO] Model batch size is fixed at " << detector->getModelBatchSize()
+                  << "; falling back to a per-image loop for " << images.size()
+                  << " image(s). Re-export with dynamic=True for true batching." << std::endl;
+    }
+
+    const auto start = std::chrono::high_resolution_clock::now();
+    std::vector<std::vector<Detection>> allResults = detector->batchDetect(images, 0.45f);
+    const auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+                              std::chrono::high_resolution_clock::now() - start);
+
+    std::cout << "Detection completed in: " << duration.count() << " ms ("
+              << (duration.count() / static_cast<double>(images.size())) << " ms/image)" << std::endl;
+
+    for (size_t i = 0; i < allResults.size(); ++i) {
+        std::cout << "\nImage: " << loadedFiles[i] << " size: " << images[i].size() << std::endl;
         std::cout << "Number of detections: " << allResults[i].size() << std::endl;
-        for(size_t j = 0; j < allResults[i].size(); ++j){
+        for (size_t j = 0; j < allResults[i].size(); ++j) {
             const Detection& det = allResults[i][j];
             std::cout << "Detection " << j << ": Class=" << det.classId
                       << ", Confidence=" << det.conf
@@ -121,9 +169,14 @@ int main(int argc, char* argv[]){
                       << "," << det.box.width << "," << det.box.height << ")" << std::endl;
         }
         // Draw bounding boxes on the image
-        detector.drawDetections(images[i], allResults[i]);
-        cv::imshow("Detections - " + std::to_string(i), images[i]);
+        detector->drawDetections(images[i], allResults[i]);
+        if (showWindows) {
+            cv::imshow("Detections - " + std::to_string(i), images[i]);
+        }
     }
-    cv::waitKey(0);
+
+    if (showWindows) {
+        cv::waitKey(0);
+    }
     return 0;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_compile_definitions("BASE_PATH_SEGMENTATION=${CMAKE_SOURCE_DIR}/segmentation
 add_compile_definitions("BASE_PATH_POSE=${CMAKE_SOURCE_DIR}/pose/")
 add_compile_definitions("BASE_PATH_OBB=${CMAKE_SOURCE_DIR}/obb/")
 add_compile_definitions("BASE_PATH_YOLOE=${CMAKE_SOURCE_DIR}/yoloe/")
+add_compile_definitions("BASE_PATH_API=${CMAKE_SOURCE_DIR}/api/")
 
 message(STATUS "Test Base Path: ${CMAKE_SOURCE_DIR}")
 
@@ -116,7 +117,7 @@ endif()
 # ============================================================================
 # Test Task Selection
 # ============================================================================
-option(testTask "Specify test task: 0=detection, 1=classification, 2=segmentation, 3=pose, 4=obb, 5=all, 6=yoloe" STRING)
+option(testTask "Specify test task: 0=detection, 1=classification, 2=segmentation, 3=pose, 4=obb, 5=all, 6=yoloe, 7=api" STRING)
 message(STATUS "Selected test task: ${testTask}")
 
 set(detection_path "${CMAKE_SOURCE_DIR}/detection")
@@ -125,6 +126,7 @@ set(segmentation_path "${CMAKE_SOURCE_DIR}/segmentation")
 set(pose_path "${CMAKE_SOURCE_DIR}/pose")
 set(obb_path "${CMAKE_SOURCE_DIR}/obb")
 set(yoloe_path "${CMAKE_SOURCE_DIR}/yoloe")
+set(api_path "${CMAKE_SOURCE_DIR}/api")
 
 set(INFERENCE_EXES)
 set(TEST_EXES)
@@ -207,6 +209,18 @@ if(testTask STREQUAL "5" OR testTask STREQUAL "6")
 endif()
 
 # ============================================================================
+# API Tests (batch inference + in-memory model loading)
+# Self-contained: runs against tiny synthetic ONNX models, no weights needed.
+# ============================================================================
+set(API_TEST_EXES)
+if(testTask STREQUAL "5" OR testTask STREQUAL "7")
+    add_executable(test_api_batch_and_memory
+        ${api_path}/test_batch_and_memory.cpp)
+
+    list(APPEND API_TEST_EXES test_api_batch_and_memory)
+endif()
+
+# ============================================================================
 # Configure Inference Executables
 # ============================================================================
 foreach(target ${INFERENCE_EXES})
@@ -249,10 +263,45 @@ foreach(target ${TEST_EXES})
 endforeach()
 
 # ============================================================================
+# Configure API Test Executables (need ONNX Runtime and OpenCV at link time)
+# ============================================================================
+foreach(target ${API_TEST_EXES})
+    message(STATUS "Adding API test target: ${target}")
+
+    target_include_directories(${target} PRIVATE
+        "${CMAKE_SOURCE_DIR}/../include"
+        "${ONNXRUNTIME_DIR}/include"
+    )
+
+    target_link_libraries(${target} PRIVATE
+        ${OpenCV_LIBS}
+        ${ONNXRUNTIME_LIB}
+        GTest::gtest_main
+        Threads::Threads
+    )
+
+    if(UNIX AND NOT APPLE)
+        set_target_properties(${target} PROPERTIES
+            BUILD_RPATH "${ONNXRUNTIME_DIR}/lib"
+            INSTALL_RPATH "${ONNXRUNTIME_DIR}/lib"
+        )
+    elseif(APPLE)
+        set_target_properties(${target} PROPERTIES
+            BUILD_RPATH "@executable_path;${ONNXRUNTIME_DIR}/lib"
+            INSTALL_RPATH "@executable_path;${ONNXRUNTIME_DIR}/lib"
+        )
+    endif()
+
+    # Loading ONNX Runtime makes test enumeration slower than the 5s default
+    gtest_discover_tests(${target} DISCOVERY_TIMEOUT 120)
+endforeach()
+
+# ============================================================================
 # Summary
 # ============================================================================
 message(STATUS "")
 message(STATUS "=== Test Suite Configuration ===")
 message(STATUS "  Inference executables: ${INFERENCE_EXES}")
 message(STATUS "  Test executables: ${TEST_EXES}")
+message(STATUS "  API test executables: ${API_TEST_EXES}")
 message(STATUS "")

--- a/tests/README.md
+++ b/tests/README.md
@@ -12,7 +12,8 @@ Comprehensive test suite validating C++ YOLO implementations against Python Ultr
 | Segmentation | 8/8 | YOLOv8, v11, YOLO26 | ✅ Pass |
 | OBB | 7/7 | YOLOv8, v11, YOLO26 | ✅ Pass |
 | YOLOE | 8/8 | yoloe-26n-seg (open-vocab, export + ONNX parity) | ✅ Pass |
-| **Total** | **44/44** parity | | **100%** |
+| API (batch + in-memory) | 22/22 | synthetic ONNX (no weights needed) | ✅ Pass |
+| **Total** | **44/44** parity + **22/22** API | | **100%** |
 
 ## Requirements
 
@@ -34,12 +35,19 @@ Comprehensive test suite validating C++ YOLO implementations against Python Ultr
 ./test_segmentation.sh
 ./test_obb.sh
 ./test_yoloe.sh
+./test_api.sh
 
 # Build only the YOLOE parity suite (after Python reference exists under yoloe/results/)
 ./build_test.sh 6
+
+# Build only the API suite (batch inference + in-memory loading)
+./build_test.sh 7
 ```
 
 ## How Tests Work
+
+The parity suites (detection, classification, segmentation, pose, OBB, YOLOE) compare
+against Ultralytics:
 
 1. **Model Download**: Downloads pretrained `.pt` files from Ultralytics
 2. **ONNX Export**: Exports models to ONNX format (opset 12)
@@ -47,6 +55,16 @@ Comprehensive test suite validating C++ YOLO implementations against Python Ultr
 4. **C++ Build**: Builds C++ inference executables
 5. **C++ Inference**: Runs C++ implementation
 6. **Comparison**: Compares results using GoogleTest
+
+The **API suite** (`test_api.sh`) is different: it tests library behavior rather than
+numeric parity, so it generates tiny synthetic ONNX models with
+`api/make_synthetic_models.py` (needs only `onnx` and `numpy`) and asserts that
+
+- `batchDetect` / `batchSegment` / `batchClassify` return exactly what a per-image loop returns
+- each batch slice is postprocessed against its own image, not against batch element 0
+- fixed-batch exports — and exports that declare a batch dim their graph cannot
+  actually run — transparently fall back to the per-image loop
+- loading a model from memory behaves identically to loading it from disk
 
 ## Directory Structure
 
@@ -60,8 +78,14 @@ tests/
 ├── test_pose.sh            # Pose estimation task runner
 ├── test_obb.sh             # OBB detection task runner
 ├── test_yoloe.sh           # YOLOE open-vocabulary segmentation parity
+├── test_api.sh             # Batch inference + in-memory loading (no weights needed)
 ├── build_test.sh           # CMake build script
 ├── CMakeLists.txt          # Test suite CMake config
+├── api/
+│   ├── make_synthetic_models.py    # Generates tiny ONNX models (shapes only)
+│   ├── test_batch_and_memory.cpp
+│   └── models/                     # Synthetic .onnx files (generated)
+│
 ├── yoloe/
 │   ├── inference_config.json       # conf, iou, and `classes` (must match export)
 │   ├── inference_yoloe_cpp.cpp
@@ -108,7 +132,7 @@ The test scripts are designed for CI/CD pipelines:
 - Exports models with compatible opset (12)
 - Returns proper exit codes (0 = pass, non-zero = fail)
 
-**GitHub Actions** (`.github/workflows/main.yml`) runs each task in parallel: `detection`, `segmentation`, `pose`, `obb`, `classification`, and **`yoloe`** (`tests/test_yoloe.sh`). Artifacts upload `tests/<task>/results/` per matrix job.
+**GitHub Actions** (`.github/workflows/main.yml`) runs each task in parallel: `detection`, `segmentation`, `pose`, `obb`, `classification`, **`yoloe`** (`tests/test_yoloe.sh`), and **`api`** (`tests/test_api.sh`). Artifacts upload `tests/<task>/results/` per matrix job.
 
 ```yaml
 # Example: run full suite locally (same tasks as CI matrix combined)

--- a/tests/api/make_synthetic_models.py
+++ b/tests/api/make_synthetic_models.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Generate tiny synthetic ONNX models for the API test suite.
+
+These models are *not* YOLO networks. They only reproduce the tensor shapes and
+the ONNX-level contract that YOLOs-CPP depends on (input NCHW layout, output
+layouts per task, dynamic vs fixed batch dimension), so the batch-inference and
+in-memory-loading code paths can be tested without downloading real weights or
+installing PyTorch/Ultralytics.
+
+Each model computes one scalar per image (the mean of that image's pixels) and
+multiplies a fixed constant tensor by it. That makes every output element depend
+on its own image and nothing else, so any batch-slicing mistake shows up as
+wrong numbers rather than as a plausible-looking result.
+
+Requires: onnx, numpy
+Usage:    python3 make_synthetic_models.py [output_dir]
+"""
+
+import os
+import sys
+
+import numpy as np
+import onnx
+from onnx import TensorProto, helper, numpy_helper
+
+OPSET = 13
+
+
+def _scaled_constant(name, const_array, reshape_dims, input_name="images"):
+    """Nodes computing `mean(input) * const_array`, broadcast over the batch.
+
+    reshape_dims is the rank the per-image scalar is reshaped to (excluding the
+    batch dim), e.g. 2 -> [B, 1, 1] so it broadcasts against a [1, F, D] constant.
+    """
+    shape = [-1] + [1] * reshape_dims
+    return (
+        [
+            helper.make_node("ReduceMean", [input_name], ["_mean"], axes=[1, 2, 3], keepdims=0),
+            helper.make_node("Reshape", ["_mean", "_reshape_" + name], ["_scale_" + name]),
+            helper.make_node("Mul", ["_scale_" + name, "_const_" + name], [name]),
+        ],
+        [
+            numpy_helper.from_array(np.array(shape, dtype=np.int64), "_reshape_" + name),
+            numpy_helper.from_array(const_array.astype(np.float32), "_const_" + name),
+        ],
+    )
+
+
+def _save(path, nodes, initializers, inputs, outputs, metadata=None):
+    graph = helper.make_graph(nodes, os.path.basename(path), inputs, outputs, initializers)
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", OPSET)])
+    model.ir_version = 8  # ONNX Runtime 1.20 supports IR <= 9; 8 is widely compatible
+    if metadata:
+        for key, value in metadata.items():
+            entry = model.metadata_props.add()
+            entry.key = key
+            entry.value = value
+    onnx.checker.check_model(model)
+    onnx.save(model, path)
+    print(f"wrote {path}")
+
+
+def _image_input(batch, size, channels=3):
+    """Input tensor info; batch=None marks the batch dimension as dynamic."""
+    dim0 = "batch" if batch is None else batch
+    return helper.make_tensor_value_info("images", TensorProto.FLOAT, [dim0, channels, size, size])
+
+
+def _output(name, batch, dims):
+    dim0 = "batch" if batch is None else batch
+    return helper.make_tensor_value_info(name, TensorProto.FLOAT, [dim0] + list(dims))
+
+
+def detection_constant(num_features, num_detections):
+    """[1, F, D] constant laid out as YOLOv8/v11 detection: cx, cy, w, h, scores."""
+    c = np.zeros((1, num_features, num_detections), dtype=np.float32)
+    num_classes = num_features - 4
+    for d in range(num_detections):
+        c[0, 0, d] = 300.0 + 5.0 * d          # cx before scaling by the image mean
+        c[0, 1, d] = 500.0 + 3.0 * d          # cy
+        c[0, 2, d] = 220.0                    # w
+        c[0, 3, d] = 180.0                    # h
+        for k in range(num_classes):
+            # A handful of confident detections per class, the rest near zero,
+            # so postprocessing and NMS both have real work to do.
+            c[0, 4 + k, d] = 1.8 if d % 17 == k else 0.05
+    return c
+
+
+def pose_constant(num_detections):
+    """[1, 56, D] constant: cx, cy, w, h, conf, then 17 keypoint triplets."""
+    c = np.zeros((1, 56, num_detections), dtype=np.float32)
+    for d in range(num_detections):
+        c[0, 0, d] = 300.0 + 5.0 * d
+        c[0, 1, d] = 500.0 + 3.0 * d
+        c[0, 2, d] = 220.0
+        c[0, 3, d] = 180.0
+        c[0, 4, d] = 1.8 if d % 17 == 0 else 0.05
+        for k in range(17):
+            c[0, 5 + k * 3 + 0, d] = 200.0 + 9.0 * k
+            c[0, 5 + k * 3 + 1, d] = 400.0 + 7.0 * k
+            c[0, 5 + k * 3 + 2, d] = 1.0
+    return c
+
+
+def obb_constant(num_labels, num_detections):
+    """[1, 5 + L, D] constant: cx, cy, w, h, scores..., angle."""
+    num_features = 5 + num_labels
+    c = np.zeros((1, num_features, num_detections), dtype=np.float32)
+    for d in range(num_detections):
+        c[0, 0, d] = 300.0 + 5.0 * d
+        c[0, 1, d] = 500.0 + 3.0 * d
+        c[0, 2, d] = 220.0
+        c[0, 3, d] = 180.0
+        for k in range(num_labels):
+            c[0, 4 + k, d] = 1.8 if d % 17 == k else 0.05
+        c[0, 4 + num_labels, d] = 1.2  # angle in radians after scaling
+    return c
+
+
+def write_models(out_dir):
+    os.makedirs(out_dir, exist_ok=True)
+
+    # ---- detection, dynamic batch (true batched path) --------------------
+    nodes, inits = _scaled_constant("output0", detection_constant(6, 100), reshape_dims=2)
+    _save(
+        os.path.join(out_dir, "det_dynamic.onnx"),
+        nodes, inits,
+        [_image_input(None, 640)],
+        [_output("output0", None, [6, 100])],
+        metadata={"names": "{0: 'alpha', 1: 'beta'}"},
+    )
+
+    # ---- detection, batch dimension fixed to 1 (fallback path) -----------
+    nodes, inits = _scaled_constant("output0", detection_constant(6, 100), reshape_dims=2)
+    _save(
+        os.path.join(out_dir, "det_batch1.onnx"),
+        nodes, inits,
+        [_image_input(1, 640)],
+        [_output("output0", 1, [6, 100])],
+    )
+
+    # ---- detection that *claims* a dynamic batch but cannot run one -------
+    # Mirrors real Ultralytics exports: the batch dim is dynamic, but a Reshape
+    # target is hard-coded for batch 1, so ONNX Runtime throws at N>1. The
+    # library must notice and fall back instead of surfacing the error.
+    nodes, inits = _scaled_constant("_scaled", detection_constant(6, 100), reshape_dims=2)
+    nodes.append(helper.make_node("Reshape", ["_scaled", "_fixed_shape"], ["output0"]))
+    inits.append(numpy_helper.from_array(np.array([1, 6, 100], dtype=np.int64), "_fixed_shape"))
+    _save(
+        os.path.join(out_dir, "det_liar.onnx"),
+        nodes, inits,
+        [_image_input(None, 640)],
+        [_output("output0", 1, [6, 100])],
+    )
+
+    # ---- segmentation, dynamic batch -------------------------------------
+    # output0: [B, 4 + 2 classes + 32 coeffs, D]; output1: [B, 32, 160, 160]
+    det_nodes, det_inits = _scaled_constant("output0", detection_constant(38, 100), reshape_dims=2)
+    protos = np.linspace(-2.0, 2.0, 32 * 160 * 160, dtype=np.float32).reshape(1, 32, 160, 160)
+    proto_nodes, proto_inits = _scaled_constant("output1", protos, reshape_dims=3)
+    # Both branches recompute the mean; drop the duplicate ReduceMean/name clash
+    proto_nodes = [n for n in proto_nodes if n.op_type != "ReduceMean"]
+    _save(
+        os.path.join(out_dir, "seg_dynamic.onnx"),
+        det_nodes + proto_nodes, det_inits + proto_inits,
+        [_image_input(None, 640)],
+        [_output("output0", None, [38, 100]), _output("output1", None, [32, 160, 160])],
+    )
+
+    # ---- pose, dynamic batch ---------------------------------------------
+    nodes, inits = _scaled_constant("output0", pose_constant(100), reshape_dims=2)
+    _save(
+        os.path.join(out_dir, "pose_dynamic.onnx"),
+        nodes, inits,
+        [_image_input(None, 640)],
+        [_output("output0", None, [56, 100])],
+    )
+
+    # ---- OBB, dynamic batch ---------------------------------------------
+    nodes, inits = _scaled_constant("output0", obb_constant(15, 100), reshape_dims=2)
+    _save(
+        os.path.join(out_dir, "obb_dynamic.onnx"),
+        nodes, inits,
+        [_image_input(None, 640)],
+        [_output("output0", None, [20, 100])],
+    )
+
+    # ---- YOLO-NAS style, dynamic batch, two outputs ----------------------
+    # Two outputs route detection through postprocessNAS, which reads both
+    # tensors — so this covers slicing more than one output per batch element.
+    boxes = np.zeros((1, 100, 4), dtype=np.float32)
+    for d in range(100):
+        boxes[0, d, 0] = 200.0 + 4.0 * d   # x1
+        boxes[0, d, 1] = 400.0 + 3.0 * d   # y1
+        boxes[0, d, 2] = 420.0 + 4.0 * d   # x2
+        boxes[0, d, 3] = 580.0 + 3.0 * d   # y2
+    scores = np.full((1, 100, 2), 0.05, dtype=np.float32)
+    for d in range(0, 100, 17):
+        scores[0, d, d % 2] = 1.8
+    box_nodes, box_inits = _scaled_constant("output0", boxes, reshape_dims=2)
+    score_nodes, score_inits = _scaled_constant("output1", scores, reshape_dims=2)
+    score_nodes = [n for n in score_nodes if n.op_type != "ReduceMean"]
+    _save(
+        os.path.join(out_dir, "nas_dynamic.onnx"),
+        box_nodes + score_nodes, box_inits + score_inits,
+        [_image_input(None, 640)],
+        [_output("output0", None, [100, 4]), _output("output1", None, [100, 2])],
+    )
+
+    # ---- detection, dynamic batch AND dynamic input shape ----------------
+    # The single-image path stride-aligns the letterbox per image while the
+    # batched path must use one shared target, so this model covers the
+    # documented divergence between the two.
+    nodes, inits = _scaled_constant("output0", detection_constant(6, 100), reshape_dims=2)
+    dyn_input = helper.make_tensor_value_info(
+        "images", TensorProto.FLOAT, ["batch", 3, "height", "width"])
+    _save(
+        os.path.join(out_dir, "det_dynshape.onnx"),
+        nodes, inits,
+        [dyn_input],
+        [_output("output0", None, [6, 100])],
+    )
+
+    # ---- classification, dynamic batch ----------------------------------
+    scores = np.linspace(0.05, 0.95, 10, dtype=np.float32).reshape(1, 10)
+    nodes, inits = _scaled_constant("output0", scores, reshape_dims=1)
+    _save(
+        os.path.join(out_dir, "cls_dynamic.onnx"),
+        nodes, inits,
+        [_image_input(None, 224)],
+        [_output("output0", None, [10])],
+    )
+
+
+if __name__ == "__main__":
+    write_models(sys.argv[1] if len(sys.argv) > 1 else "models")

--- a/tests/api/test_batch_and_memory.cpp
+++ b/tests/api/test_batch_and_memory.cpp
@@ -1,0 +1,497 @@
+/**
+ * @file test_batch_and_memory.cpp
+ * @brief API tests for batch inference and in-memory model loading
+ *
+ * These tests run against the tiny synthetic ONNX models produced by
+ * make_synthetic_models.py, so they need neither real weights nor Ultralytics.
+ *
+ * The invariants under test:
+ *   - batch* methods return exactly what a per-image loop returns
+ *   - each batch slice is postprocessed against its own image, not image 0
+ *   - fixed-batch models transparently fall back to the per-image loop
+ *   - loading a model from memory behaves identically to loading it from disk
+ */
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "yolos/yolos.hpp"
+
+#define STRING(x) #x
+#define XSTRING(x) STRING(x)
+
+namespace fs = std::filesystem;
+
+namespace {
+
+const std::string kModelDir = std::string(XSTRING(BASE_PATH_API)) + "models/";
+
+std::string modelPath(const std::string& name) { return kModelDir + name; }
+
+/// Images with distinct sizes and distinct mean intensities: the synthetic
+/// models key their output off the image mean, and the differing sizes force
+/// per-image letterbox scale/padding during postprocessing.
+std::vector<cv::Mat> makeTestImages() {
+    return {
+        cv::Mat(480, 640, CV_8UC3, cv::Scalar(10, 20, 30)),
+        cv::Mat(900, 300, CV_8UC3, cv::Scalar(200, 180, 160)),
+        cv::Mat(500, 500, CV_8UC3, cv::Scalar(90, 90, 90)),
+        cv::Mat(720, 1280, CV_8UC3, cv::Scalar(250, 5, 5)),
+    };
+}
+
+void expectSameDetections(const std::vector<yolos::det::Detection>& expected,
+                          const std::vector<yolos::det::Detection>& actual,
+                          const std::string& context) {
+    ASSERT_EQ(expected.size(), actual.size()) << context;
+    for (size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(expected[i].classId, actual[i].classId) << context << " det " << i;
+        EXPECT_NEAR(expected[i].conf, actual[i].conf, 1e-4f) << context << " det " << i;
+        EXPECT_EQ(expected[i].box.x, actual[i].box.x) << context << " det " << i;
+        EXPECT_EQ(expected[i].box.y, actual[i].box.y) << context << " det " << i;
+        EXPECT_EQ(expected[i].box.width, actual[i].box.width) << context << " det " << i;
+        EXPECT_EQ(expected[i].box.height, actual[i].box.height) << context << " det " << i;
+    }
+}
+
+} // namespace
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+class SyntheticModelTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite() {
+        // Check a concrete model, not just the directory: the .onnx files are
+        // generated (and gitignored), so a stale empty directory is the likely
+        // failure and should produce this message rather than an ORT error.
+        ASSERT_TRUE(fs::exists(modelPath("det_dynamic.onnx")))
+            << "Synthetic models missing from " << kModelDir
+            << "\nRun: python3 tests/api/make_synthetic_models.py tests/api/models";
+    }
+};
+
+// ============================================================================
+// Detection: batched path
+// ============================================================================
+
+TEST_F(SyntheticModelTest, DetectionBatchMatchesSequential) {
+    yolos::det::YOLODetector detector(modelPath("det_dynamic.onnx"), "", false);
+    ASSERT_TRUE(detector.isDynamicBatchSize()) << "det_dynamic.onnx should have a dynamic batch dim";
+
+    const std::vector<cv::Mat> images = makeTestImages();
+    ASSERT_TRUE(detector.supportsBatchSize(images.size()));
+
+    std::vector<std::vector<yolos::det::Detection>> sequential;
+    for (const auto& image : images) {
+        sequential.push_back(detector.detect(image, 0.25f, 0.45f));
+    }
+
+    const auto batched = detector.batchDetect(images, 0.25f, 0.45f);
+
+    ASSERT_EQ(images.size(), batched.size());
+    for (size_t i = 0; i < images.size(); ++i) {
+        expectSameDetections(sequential[i], batched[i], "image " + std::to_string(i));
+    }
+}
+
+TEST_F(SyntheticModelTest, DetectionBatchProducesNonEmptyPerImageResults) {
+    yolos::det::YOLODetector detector(modelPath("det_dynamic.onnx"), "", false);
+
+    const std::vector<cv::Mat> images = makeTestImages();
+    const auto batched = detector.batchDetect(images, 0.25f, 0.45f);
+
+    ASSERT_EQ(images.size(), batched.size());
+    for (size_t i = 0; i < batched.size(); ++i) {
+        EXPECT_FALSE(batched[i].empty()) << "image " << i << " produced no detections";
+    }
+}
+
+TEST_F(SyntheticModelTest, DetectionBatchSlicesAreImageSpecific) {
+    // Guards against every slice being postprocessed from batch element 0:
+    // the images have different means, so their detections must differ.
+    yolos::det::YOLODetector detector(modelPath("det_dynamic.onnx"), "", false);
+
+    const std::vector<cv::Mat> images = makeTestImages();
+    const auto batched = detector.batchDetect(images, 0.25f, 0.45f);
+
+    ASSERT_GE(batched.size(), 2u);
+    ASSERT_FALSE(batched[0].empty());
+    ASSERT_FALSE(batched[1].empty());
+    EXPECT_NE(batched[0][0].conf, batched[1][0].conf)
+        << "different images yielded identical confidences";
+}
+
+TEST_F(SyntheticModelTest, DetectionBatchWithEmptyInputReturnsEmpty) {
+    yolos::det::YOLODetector detector(modelPath("det_dynamic.onnx"), "", false);
+    EXPECT_TRUE(detector.batchDetect({}, 0.25f, 0.45f).empty());
+}
+
+TEST_F(SyntheticModelTest, DetectionBatchOfOneMatchesDetect) {
+    yolos::det::YOLODetector detector(modelPath("det_dynamic.onnx"), "", false);
+
+    const cv::Mat image = makeTestImages()[2];
+    const auto expected = detector.detect(image, 0.25f, 0.45f);
+    const auto batched = detector.batchDetect({image}, 0.25f, 0.45f);
+
+    ASSERT_EQ(1u, batched.size());
+    expectSameDetections(expected, batched[0], "single-image batch");
+}
+
+TEST_F(SyntheticModelTest, TwoOutputDetectionBatchMatchesSequential) {
+    // Two outputs route through postprocessNAS, which reads both tensors —
+    // so this covers slicing more than one output per batch element.
+    yolos::det::YOLODetector detector(modelPath("nas_dynamic.onnx"), "", false);
+    ASSERT_EQ(2u, detector.getNumOutputNodes());
+    ASSERT_TRUE(detector.isDynamicBatchSize());
+
+    const std::vector<cv::Mat> images = makeTestImages();
+
+    std::vector<std::vector<yolos::det::Detection>> sequential;
+    for (const auto& image : images) {
+        sequential.push_back(detector.detect(image, 0.25f, 0.45f));
+    }
+
+    const auto batched = detector.batchDetect(images, 0.25f, 0.45f);
+
+    ASSERT_EQ(images.size(), batched.size());
+    for (size_t i = 0; i < images.size(); ++i) {
+        EXPECT_FALSE(batched[i].empty()) << "image " << i << " produced no detections";
+        expectSameDetections(sequential[i], batched[i], "two-output image " + std::to_string(i));
+    }
+}
+
+TEST_F(SyntheticModelTest, DynamicInputShapeModelStillBatches) {
+    // Batching needs one shared letterbox target, so for a dynamic-input-shape
+    // model the batched path uses the model input shape while detect() picks a
+    // per-image stride-aligned shape. Results may differ; the batch must still
+    // be correct and per-image.
+    yolos::det::YOLODetector detector(modelPath("det_dynshape.onnx"), "", false);
+    ASSERT_TRUE(detector.isDynamicInputShape());
+    ASSERT_TRUE(detector.isDynamicBatchSize());
+
+    const std::vector<cv::Mat> images = makeTestImages();
+    const auto batched = detector.batchDetect(images, 0.25f, 0.45f);
+
+    ASSERT_EQ(images.size(), batched.size());
+    for (size_t i = 0; i < batched.size(); ++i) {
+        EXPECT_FALSE(batched[i].empty()) << "image " << i << " produced no detections";
+    }
+    EXPECT_NE(batched[0][0].conf, batched[1][0].conf)
+        << "different images yielded identical confidences";
+
+    // Same shared target as an explicit batch of one, so those must agree.
+    const auto single = detector.batchDetect({images[1]}, 0.25f, 0.45f);
+    ASSERT_EQ(1u, single.size());
+    expectSameDetections(single[0], batched[1], "dynamic-shape batch of one vs batch of four");
+}
+
+// ============================================================================
+// Detection: fixed-batch fallback
+// ============================================================================
+
+TEST_F(SyntheticModelTest, FixedBatchModelFallsBackToPerImageLoop) {
+    yolos::det::YOLODetector detector(modelPath("det_batch1.onnx"), "", false);
+
+    EXPECT_FALSE(detector.isDynamicBatchSize());
+    EXPECT_EQ(1, detector.getModelBatchSize());
+
+    const std::vector<cv::Mat> images = makeTestImages();
+    EXPECT_FALSE(detector.supportsBatchSize(images.size()));
+    EXPECT_TRUE(detector.supportsBatchSize(1));
+
+    std::vector<std::vector<yolos::det::Detection>> sequential;
+    for (const auto& image : images) {
+        sequential.push_back(detector.detect(image, 0.25f, 0.45f));
+    }
+
+    // Falls back internally, but the caller still gets one result per image.
+    const auto batched = detector.batchDetect(images, 0.25f, 0.45f);
+
+    ASSERT_EQ(images.size(), batched.size());
+    for (size_t i = 0; i < images.size(); ++i) {
+        expectSameDetections(sequential[i], batched[i], "fallback image " + std::to_string(i));
+    }
+}
+
+TEST_F(SyntheticModelTest, ModelThatClaimsDynamicBatchButCannotRunOneFallsBack) {
+    // Real Ultralytics exports bake batch=1 into DFL Reshape / anchor Concat
+    // nodes even when the declared batch dim is dynamic, so the batched run
+    // throws. det_liar.onnx reproduces that: the caller must still get results.
+    yolos::det::YOLODetector detector(modelPath("det_liar.onnx"), "", false);
+
+    const std::vector<cv::Mat> images = makeTestImages();
+    ASSERT_TRUE(detector.isDynamicBatchSize());
+    ASSERT_TRUE(detector.supportsBatchSize(images.size())) << "the model advertises a batch it cannot run";
+
+    std::vector<std::vector<yolos::det::Detection>> sequential;
+    for (const auto& image : images) {
+        sequential.push_back(detector.detect(image, 0.25f, 0.45f));
+    }
+
+    // Batched run fails inside ONNX Runtime; batchDetect must recover.
+    const auto batched = detector.batchDetect(images, 0.25f, 0.45f);
+
+    ASSERT_EQ(images.size(), batched.size());
+    for (size_t i = 0; i < images.size(); ++i) {
+        EXPECT_FALSE(batched[i].empty()) << "image " << i << " produced no detections";
+        expectSameDetections(sequential[i], batched[i], "recovered image " + std::to_string(i));
+    }
+}
+
+// ============================================================================
+// In-memory model loading
+// ============================================================================
+
+TEST_F(SyntheticModelTest, InMemoryLoadingMatchesFileLoading) {
+    const std::vector<std::string> classNames = {"first", "second"};
+
+    yolos::det::YOLODetector fromFile(modelPath("det_dynamic.onnx"), "", false);
+
+    const std::vector<uint8_t> bytes = yolos::utils::readFileBytes(modelPath("det_dynamic.onnx"));
+    ASSERT_FALSE(bytes.empty());
+    yolos::det::YOLODetector fromMemory(bytes.data(), bytes.size(), classNames, false);
+
+    EXPECT_EQ(fromFile.getInputShape(), fromMemory.getInputShape());
+    EXPECT_EQ(fromFile.isDynamicBatchSize(), fromMemory.isDynamicBatchSize());
+    EXPECT_EQ(classNames, fromMemory.getClassNames());
+
+    const std::vector<cv::Mat> images = makeTestImages();
+    for (size_t i = 0; i < images.size(); ++i) {
+        expectSameDetections(fromFile.detect(images[i], 0.25f, 0.45f),
+                             fromMemory.detect(images[i], 0.25f, 0.45f),
+                             "memory-vs-file image " + std::to_string(i));
+    }
+}
+
+TEST_F(SyntheticModelTest, InMemoryLoadingSurvivesBufferRelease) {
+    // ONNX Runtime copies the model during session creation, which is what lets
+    // callers wipe an decrypted buffer immediately after construction.
+    std::vector<uint8_t> bytes = yolos::utils::readFileBytes(modelPath("det_dynamic.onnx"));
+    ASSERT_FALSE(bytes.empty());
+
+    yolos::det::YOLODetector detector(bytes.data(), bytes.size(), {"first", "second"}, false);
+
+    std::fill(bytes.begin(), bytes.end(), uint8_t{0});
+    bytes.clear();
+    bytes.shrink_to_fit();
+
+    EXPECT_FALSE(detector.detect(makeTestImages()[0], 0.25f, 0.45f).empty());
+}
+
+TEST_F(SyntheticModelTest, InMemoryLoadingFallsBackToOnnxMetadataNames) {
+    // det_dynamic.onnx carries Ultralytics-style names metadata {0: alpha, 1: beta}
+    const std::vector<uint8_t> bytes = yolos::utils::readFileBytes(modelPath("det_dynamic.onnx"));
+    ASSERT_FALSE(bytes.empty());
+
+    yolos::det::YOLODetector detector(bytes.data(), bytes.size(), {}, false);
+
+    const std::vector<std::string> expected = {"alpha", "beta"};
+    EXPECT_EQ(expected, detector.getClassNames());
+}
+
+TEST_F(SyntheticModelTest, InMemoryLoadingRejectsEmptyBuffer) {
+    EXPECT_THROW(
+        yolos::det::YOLODetector(nullptr, 0, {"a"}, false),
+        std::invalid_argument);
+
+    const std::vector<uint8_t> bytes = {1, 2, 3};
+    EXPECT_THROW(
+        yolos::det::YOLODetector(bytes.data(), 0, {"a"}, false),
+        std::invalid_argument);
+}
+
+TEST_F(SyntheticModelTest, InMemoryDetectorSupportsBatchInference) {
+    const std::vector<uint8_t> bytes = yolos::utils::readFileBytes(modelPath("det_dynamic.onnx"));
+    ASSERT_FALSE(bytes.empty());
+
+    yolos::det::YOLODetector detector(bytes.data(), bytes.size(), {"first", "second"}, false);
+
+    const std::vector<cv::Mat> images = makeTestImages();
+    const auto batched = detector.batchDetect(images, 0.25f, 0.45f);
+    ASSERT_EQ(images.size(), batched.size());
+
+    for (size_t i = 0; i < images.size(); ++i) {
+        expectSameDetections(detector.detect(images[i], 0.25f, 0.45f), batched[i],
+                             "in-memory batch image " + std::to_string(i));
+    }
+}
+
+TEST_F(SyntheticModelTest, CreateDetectorFromMemoryFactory) {
+    const std::vector<uint8_t> bytes = yolos::utils::readFileBytes(modelPath("det_dynamic.onnx"));
+    ASSERT_FALSE(bytes.empty());
+
+    auto detector = yolos::det::createDetectorFromMemory(
+        bytes.data(), bytes.size(), {"first", "second"}, yolos::YOLOVersion::V11, false);
+
+    ASSERT_NE(nullptr, detector);
+    EXPECT_FALSE(detector->detect(makeTestImages()[0], 0.25f, 0.45f).empty());
+}
+
+// ============================================================================
+// Segmentation
+// ============================================================================
+
+TEST_F(SyntheticModelTest, SegmentationBatchMatchesSequential) {
+    yolos::seg::YOLOSegDetector segmenter(modelPath("seg_dynamic.onnx"), "", false);
+    ASSERT_TRUE(segmenter.isDynamicBatchSize());
+
+    const std::vector<cv::Mat> images = makeTestImages();
+
+    std::vector<std::vector<yolos::seg::Segmentation>> sequential;
+    for (const auto& image : images) {
+        sequential.push_back(segmenter.segment(image, 0.25f, 0.45f));
+    }
+
+    const auto batched = segmenter.batchSegment(images, 0.25f, 0.45f);
+
+    ASSERT_EQ(images.size(), batched.size());
+    for (size_t i = 0; i < images.size(); ++i) {
+        ASSERT_EQ(sequential[i].size(), batched[i].size()) << "image " << i;
+        for (size_t d = 0; d < sequential[i].size(); ++d) {
+            EXPECT_EQ(sequential[i][d].classId, batched[i][d].classId) << "image " << i;
+            EXPECT_NEAR(sequential[i][d].conf, batched[i][d].conf, 1e-4f) << "image " << i;
+            EXPECT_EQ(sequential[i][d].box.x, batched[i][d].box.x) << "image " << i;
+            EXPECT_EQ(sequential[i][d].box.y, batched[i][d].box.y) << "image " << i;
+            EXPECT_EQ(sequential[i][d].box.width, batched[i][d].box.width) << "image " << i;
+            EXPECT_EQ(sequential[i][d].box.height, batched[i][d].box.height) << "image " << i;
+
+            // Masks must be identical pixel for pixel, which is what proves the
+            // prototype tensor was sliced on the right batch element.
+            ASSERT_EQ(sequential[i][d].mask.size(), batched[i][d].mask.size()) << "image " << i;
+            EXPECT_EQ(0, cv::countNonZero(sequential[i][d].mask != batched[i][d].mask))
+                << "mask mismatch for image " << i << " detection " << d;
+        }
+    }
+}
+
+TEST_F(SyntheticModelTest, SegmentationInMemoryLoading) {
+    const std::vector<uint8_t> bytes = yolos::utils::readFileBytes(modelPath("seg_dynamic.onnx"));
+    ASSERT_FALSE(bytes.empty());
+
+    yolos::seg::YOLOSegDetector fromMemory(bytes.data(), bytes.size(), {"first", "second"}, false);
+    yolos::seg::YOLOSegDetector fromFile(modelPath("seg_dynamic.onnx"), "", false);
+
+    const cv::Mat image = makeTestImages()[1];
+    EXPECT_EQ(fromFile.segment(image, 0.25f, 0.45f).size(),
+              fromMemory.segment(image, 0.25f, 0.45f).size());
+}
+
+// ============================================================================
+// Pose
+// ============================================================================
+
+TEST_F(SyntheticModelTest, PoseBatchMatchesSequential) {
+    yolos::pose::YOLOPoseDetector poser(modelPath("pose_dynamic.onnx"), "", false);
+    ASSERT_TRUE(poser.isDynamicBatchSize());
+
+    const std::vector<cv::Mat> images = makeTestImages();
+
+    std::vector<std::vector<yolos::pose::PoseResult>> sequential;
+    for (const auto& image : images) {
+        sequential.push_back(poser.detect(image, 0.25f, 0.5f));
+    }
+
+    const auto batched = poser.batchDetect(images, 0.25f, 0.5f);
+
+    ASSERT_EQ(images.size(), batched.size());
+    for (size_t i = 0; i < images.size(); ++i) {
+        ASSERT_EQ(sequential[i].size(), batched[i].size()) << "image " << i;
+        for (size_t d = 0; d < sequential[i].size(); ++d) {
+            EXPECT_NEAR(sequential[i][d].conf, batched[i][d].conf, 1e-4f) << "image " << i;
+            EXPECT_EQ(sequential[i][d].box.x, batched[i][d].box.x) << "image " << i;
+            EXPECT_EQ(sequential[i][d].box.y, batched[i][d].box.y) << "image " << i;
+            ASSERT_EQ(sequential[i][d].keypoints.size(), batched[i][d].keypoints.size());
+            for (size_t k = 0; k < sequential[i][d].keypoints.size(); ++k) {
+                EXPECT_NEAR(sequential[i][d].keypoints[k].x, batched[i][d].keypoints[k].x, 1e-2f);
+                EXPECT_NEAR(sequential[i][d].keypoints[k].y, batched[i][d].keypoints[k].y, 1e-2f);
+            }
+        }
+    }
+}
+
+// ============================================================================
+// OBB
+// ============================================================================
+
+TEST_F(SyntheticModelTest, ObbBatchMatchesSequential) {
+    yolos::obb::YOLOOBBDetector obbDetector(modelPath("obb_dynamic.onnx"), "", false);
+    ASSERT_TRUE(obbDetector.isDynamicBatchSize());
+
+    const std::vector<cv::Mat> images = makeTestImages();
+
+    std::vector<std::vector<yolos::obb::OBBResult>> sequential;
+    for (const auto& image : images) {
+        sequential.push_back(obbDetector.detect(image, 0.25f, 0.45f, 300));
+    }
+
+    const auto batched = obbDetector.batchDetect(images, 0.25f, 0.45f, 300);
+
+    ASSERT_EQ(images.size(), batched.size());
+    for (size_t i = 0; i < images.size(); ++i) {
+        ASSERT_EQ(sequential[i].size(), batched[i].size()) << "image " << i;
+        for (size_t d = 0; d < sequential[i].size(); ++d) {
+            EXPECT_EQ(sequential[i][d].classId, batched[i][d].classId) << "image " << i;
+            EXPECT_NEAR(sequential[i][d].conf, batched[i][d].conf, 1e-4f) << "image " << i;
+            EXPECT_NEAR(sequential[i][d].box.x, batched[i][d].box.x, 1e-2f) << "image " << i;
+            EXPECT_NEAR(sequential[i][d].box.y, batched[i][d].box.y, 1e-2f) << "image " << i;
+            EXPECT_NEAR(sequential[i][d].box.angle, batched[i][d].box.angle, 1e-4f) << "image " << i;
+        }
+    }
+}
+
+// ============================================================================
+// Classification
+// ============================================================================
+
+TEST_F(SyntheticModelTest, ClassificationBatchMatchesSequential) {
+    const std::vector<std::string> classNames = {
+        "c0", "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9"};
+
+    const std::vector<uint8_t> bytes = yolos::utils::readFileBytes(modelPath("cls_dynamic.onnx"));
+    ASSERT_FALSE(bytes.empty());
+    yolos::cls::YOLOClassifier classifier(bytes.data(), bytes.size(), classNames, false);
+    ASSERT_TRUE(classifier.isDynamicBatchSize());
+
+    const std::vector<cv::Mat> images = makeTestImages();
+
+    std::vector<yolos::cls::ClassificationResult> sequential;
+    for (const auto& image : images) {
+        sequential.push_back(classifier.classify(image));
+    }
+
+    const auto batched = classifier.batchClassify(images);
+
+    ASSERT_EQ(images.size(), batched.size());
+    for (size_t i = 0; i < images.size(); ++i) {
+        EXPECT_EQ(sequential[i].classId, batched[i].classId) << "image " << i;
+        EXPECT_EQ(sequential[i].className, batched[i].className) << "image " << i;
+        EXPECT_NEAR(sequential[i].confidence, batched[i].confidence, 1e-5f) << "image " << i;
+    }
+}
+
+TEST_F(SyntheticModelTest, ClassificationBatchHandlesEmptyImages) {
+    const std::vector<uint8_t> bytes = yolos::utils::readFileBytes(modelPath("cls_dynamic.onnx"));
+    ASSERT_FALSE(bytes.empty());
+    yolos::cls::YOLOClassifier classifier(bytes.data(), bytes.size(), {"c0"}, false);
+
+    // An empty Mat forces the per-image path; the empty slot still gets a result.
+    std::vector<cv::Mat> images = makeTestImages();
+    images.push_back(cv::Mat());
+
+    const auto batched = classifier.batchClassify(images);
+    ASSERT_EQ(images.size(), batched.size());
+    EXPECT_EQ(-1, batched.back().classId);
+}
+
+TEST_F(SyntheticModelTest, ClassificationBatchWithEmptyInputReturnsEmpty) {
+    const std::vector<uint8_t> bytes = yolos::utils::readFileBytes(modelPath("cls_dynamic.onnx"));
+    ASSERT_FALSE(bytes.empty());
+    yolos::cls::YOLOClassifier classifier(bytes.data(), bytes.size(), {"c0"}, false);
+
+    EXPECT_TRUE(classifier.batchClassify({}).empty());
+}

--- a/tests/build_test.sh
+++ b/tests/build_test.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
 # Default values
-TEST_TASK="${1:-0}"           # 0=detection, 1=classification, 2=segmentation, 3=pose, 4=obb, 5=all, 6=yoloe
+TEST_TASK="${1:-0}"           # 0=detection, 1=classification, 2=segmentation, 3=pose, 4=obb, 5=all, 6=yoloe, 7=api
 ONNXRUNTIME_VERSION="${2:-1.20.1}"
 ONNXRUNTIME_GPU="${3:-0}"     # 0=CPU, 1=GPU
 
@@ -32,6 +32,7 @@ usage() {
     echo "                        4 = OBB"
     echo "                        5 = All tasks"
     echo "                        6 = YOLOE open-vocabulary segmentation parity (vs Ultralytics)"
+    echo "                        7 = API tests (batch inference + in-memory model loading)"
     echo "  ONNXRUNTIME_VERSION Version of ONNX Runtime (default: 1.20.1)"
     echo "  ONNXRUNTIME_GPU     0 = CPU, 1 = GPU (default: 0)"
     echo ""
@@ -67,6 +68,16 @@ detect_platform() {
         i*86)          ONNXRUNTIME_ARCH="x86" ;;
         *) echo -e "${RED}Unsupported architecture: $arch${NC}"; exit 1 ;;
     esac
+
+    # macOS release assets use different arch names than Linux/Windows ones
+    # (onnxruntime-osx-arm64 / onnxruntime-osx-x86_64), and CMakeLists.txt
+    # searches for exactly those directory names.
+    if [[ "$ONNXRUNTIME_PLATFORM" == "osx" ]]; then
+        case "$arch" in
+            aarch64|arm64) ONNXRUNTIME_ARCH="arm64" ;;
+            x86_64)        ONNXRUNTIME_ARCH="x86_64" ;;
+        esac
+    fi
 
     # Build ONNX Runtime paths
     ONNXRUNTIME_FILE="onnxruntime-${ONNXRUNTIME_PLATFORM}-${ONNXRUNTIME_ARCH}"

--- a/tests/test_all.sh
+++ b/tests/test_all.sh
@@ -48,6 +48,7 @@ run_test "Segmentation" "$SCRIPT_DIR/test_segmentation.sh"
 run_test "Pose" "$SCRIPT_DIR/test_pose.sh"
 run_test "OBB" "$SCRIPT_DIR/test_obb.sh"
 run_test "YOLOE" "$SCRIPT_DIR/test_yoloe.sh"
+run_test "API (batch + in-memory)" "$SCRIPT_DIR/test_api.sh"
 
 # ============================================================================
 # Summary

--- a/tests/test_api.sh
+++ b/tests/test_api.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# ============================================================================
+# YOLOs-CPP API Test Runner (batch inference + in-memory model loading)
+# ============================================================================
+# Self-contained: generates tiny synthetic ONNX models instead of downloading
+# real weights, so it needs only `onnx` and `numpy` (no PyTorch/Ultralytics).
+# ============================================================================
+set -e
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+source "$SCRIPT_DIR/test_utils.sh"
+
+print_header "YOLOs-CPP API Test (batch inference + in-memory loading)"
+
+# ============================================================================
+# Generate Synthetic Models
+# ============================================================================
+print_header "Installing Dependencies"
+install_uv
+install_python_packages onnx numpy
+
+print_header "Generating Synthetic ONNX Models"
+cd "$SCRIPT_DIR/api"
+python3 make_synthetic_models.py models || {
+    print_error "Failed to generate synthetic models"
+    exit 1
+}
+print_success "Synthetic models generated"
+
+# ============================================================================
+# Build and Run Tests
+# ============================================================================
+print_header "Building Test Suite"
+cd "$SCRIPT_DIR"
+./build_test.sh 7
+
+print_header "Running API Tests"
+cd build
+./test_api_batch_and_memory
+
+print_success "API tests completed!"


### PR DESCRIPTION
Closes #143.

Adds the two features requested in the issue: in-memory model loading and batch inference.

## In-memory model loading

Every task class gains a constructor taking the serialized ONNX bytes plus class names as a vector — no file path, no labels file:

```cpp
// Bytes from anywhere: decryption, download, embedded array
std::vector<uint8_t> bytes = yolos::utils::readFileBytes("yolo11n.onnx");
yolos::det::YOLODetector detector(bytes.data(), bytes.size(), {"person", "bicycle", "car"});
```

- `OrtSessionBase::initSession` is split into `configureSessionOptions()` + `introspectSession()`, so the path and buffer constructors share everything but the `Ort::Session` creation call.
- An empty `classNames` falls back to the Ultralytics `names` ONNX metadata. A null or zero-length buffer throws `std::invalid_argument`.
- ONNX Runtime copies the buffer during session creation, so callers may wipe it as soon as the constructor returns (documented, and covered by a test).
- Added for detection (plus all version-pinned subclasses), segmentation, pose, OBB, classification and YOLOE, with matching `create*FromMemory()` factories.

## Batch inference

`batchDetect` / `batchSegment` / `batchClassify` pack N images into one `N×C×H×W` tensor for a single ONNX Runtime call.

```cpp
auto results = detector.batchDetect(images, /*conf=*/0.25f, /*iou=*/0.45f);  // one vector per image
```

**Design note.** Rather than change five `virtual postprocess*` signatures — which would break downstream subclasses of a header-only library — `OrtSessionBase::sliceOutputBatch()` builds **zero-copy `[1, …]` views** into the batched output tensors. The existing single-image postprocessing then runs unchanged per batch element, so subclass overrides, segmentation's mask prototypes and YOLO-NAS's second output all keep working with no duplicated decode logic.

**Fallback**, as the issue asked for. A per-image loop is used whenever one call cannot serve the batch:

| Case | Behavior |
|---|---|
| Fixed batch dim ≠ `images.size()` | per-image loop |
| Non-float outputs | per-image loop |
| Declares a dynamic batch dim the graph can't run | `Ort::Exception` caught, warning logged, per-image loop |

That last row is not hypothetical: Ultralytics static exports bake `batch=1` into DFL `Reshape` and anchor `Concat` nodes, so a model can advertise a batch size it cannot actually run. Callers can check up front with `isDynamicBatchSize()`, `getModelBatchSize()` and `supportsBatchSize(n)`.

**One documented behavioral difference.** A batched tensor requires a single shared letterbox target, so batched runs letterbox to the model input shape while the single-image paths stride-align per image. Fixed-input-shape models — the common case — are bit-identical either way; the divergence only affects dynamic-input-shape models and is called out in the API docs.

## Tests

New self-contained suite (`tests/api/`, task `7`, wired into CI and `test_all.sh`): **22 tests**, all passing. It runs against tiny synthetic ONNX models generated by `make_synthetic_models.py` — only `onnx` and `numpy` required, no weights and no Ultralytics, so it is fast and cannot bit-rot on model downloads. The models are not YOLO networks; they reproduce the tensor shapes and per-task output layouts, and each output element is derived from its own image's mean so that any batch-slicing mistake shows up as wrong numbers.

Asserted invariants:

- `batch*` returns exactly what a per-image loop returns (boxes exact, masks pixel-for-pixel)
- each slice is postprocessed against its own image, not against batch element 0
- both fallback kinds recover and still return one result per image
- in-memory loading matches file loading, survives the buffer being wiped, reads metadata names, and rejects empty buffers
- covered per task: detection, 2-output/NAS routing, dynamic-input-shape, segmentation, pose, OBB, classification

## Verification performed

- **Mutation-tested the tests.** Forcing `sliceOutputBatch` to always read batch index 0 fails 6 tests across detection, segmentation, pose and OBB; forcing classification's score offset to 0 fails its test. Restored, all 22 green.
- **Real models.** Against 8 real exports from this repo's releases (v5/v6/v8/v9/v10/v11 VOC-tuned): in-memory loading gives detections identical to file loading, and the fallback path returns exactly what the per-image loop returns.
- **Full build clean**, including `BUILD_EXAMPLES=ON`.

**Known gap, stated plainly:** the true-batch path is verified against synthetic dynamic-batch models, **not** against a genuine `model.export(dynamic=True)` Ultralytics export — none was obtainable in my environment, and static exports cannot be patched into batchable ones (fixing the DFL `Reshape` just moves the failure to the anchor `Concat`, verified twice). Worth one run with a real dynamic export before merging; the fallback means non-batchable models are safe regardless.

## Also in this PR

- `src/batch_image_inference.cpp` advertised batch inference in its docstring while looping per image. It now calls `batchDetect` and has an `--in-memory` flag, so both features have a runnable demo.
- `preprocessing`: new `letterBoxToBlobPtr()` (one image into a caller-owned CHW slice) and `letterBoxToBatchBlob()` (N images into one blob). The existing `letterBoxToBlob` overloads delegate to them with unchanged semantics.
- Docs: new "Batch Inference" and "In-Memory Model Loading" sections in `docs/api/api.md`, signatures added to every task block, plus `docs/examples/examples.md`, `README.md` and `tests/README.md`.
- Separate first commit fixes an unrelated pre-existing bug: `tests/build_test.sh` requested `onnxruntime-osx-aarch64-*` on macOS, but the release asset is `osx-arm64` (which is also what `CMakeLists.txt` looks for), so the test suite could never bootstrap on macOS. Reviewable and revertable on its own.
