### PR TITLE
fix(cls): match Ultralytics classification preprocessing (#137)

### DIFF
--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -338,6 +338,16 @@ auto result = classifier.classify(frame);
 classifier.drawResult(frame, result);
 ```
 
+**Preprocessing.** `classify()` reproduces `ultralytics.data.augment.classify_transforms()`:
+resize the shortest edge to the model input size, centre-crop to a square, scale to
+`[0, 1]`. Ultralytics resizes through PIL, whose bilinear filter is **antialiased**, so
+YOLOs-CPP uses `preprocessing::resizeAntialiasBilinear()` rather than
+`cv::resize(INTER_LINEAR)`. Using a plain bilinear resize here inflates confidences and
+can change the top-1 class on downscaled images.
+
+This differs from the other tasks on purpose: Ultralytics' `LetterBox` (detection,
+segmentation, pose, OBB) really does use `cv2.INTER_LINEAR`, so those paths keep it.
+
 ---
 
 ## Base Session — `yolos::OrtSessionBase`

--- a/include/yolos/core/preprocessing.hpp
+++ b/include/yolos/core/preprocessing.hpp
@@ -487,5 +487,160 @@ inline void descaleCoordsBatch(float* coords, size_t count,
     }
 }
 
+// ============================================================================
+// Antialiased Bilinear Resize (PIL-compatible)
+// ============================================================================
+// Ultralytics preprocesses classification images with torchvision's
+// T.Resize(size, BILINEAR) applied to a PIL image, and PIL's BILINEAR filter is
+// *antialiased*: its support widens with the downscale factor so every source
+// pixel contributes. cv::resize(INTER_LINEAR) always samples a 2x2 neighborhood
+// and therefore aliases when downscaling, which shifted classification
+// confidences noticeably and could even change the top-1 class.
+//
+// The functions below reproduce Pillow's algorithm (src/libImaging/Resample.c).
+
+namespace detail {
+
+/// @brief Per-output-pixel filter weights for one axis
+struct ResampleCoeffs {
+    int ksize{0};                  ///< Stride between per-pixel weight runs
+    std::vector<float> weights;    ///< outSize * ksize weights
+    std::vector<int> starts;       ///< First contributing source index
+    std::vector<int> counts;       ///< Number of contributing source pixels
+};
+
+/// @brief Round-half-up then clamp to a byte, matching Pillow's clip8()
+inline uchar clip8(double value) {
+    const int rounded = static_cast<int>(std::floor(value + 0.5));
+    return static_cast<uchar>(rounded < 0 ? 0 : (rounded > 255 ? 255 : rounded));
+}
+
+/// @brief Compute Pillow's triangle-filter weights for one axis
+/// @param inSize Source length along the axis
+/// @param outSize Destination length along the axis
+/// @note The support scales with the downscale factor, which is what produces
+///       the antialiasing. When upscaling, filterscale clamps to 1.0 and this
+///       degenerates to ordinary bilinear interpolation.
+inline ResampleCoeffs computeBilinearCoeffs(int inSize, int outSize) {
+    constexpr double filterSupport = 1.0;  // Pillow's BILINEAR support
+
+    const double scale = static_cast<double>(inSize) / outSize;
+    const double filterscale = (scale < 1.0) ? 1.0 : scale;
+    const double support = filterSupport * filterscale;
+    const double invFilterscale = 1.0 / filterscale;
+
+    ResampleCoeffs coeffs;
+    coeffs.ksize = static_cast<int>(std::ceil(support)) * 2 + 1;
+    coeffs.weights.assign(static_cast<size_t>(outSize) * coeffs.ksize, 0.0f);
+    coeffs.starts.resize(outSize);
+    coeffs.counts.resize(outSize);
+
+    for (int i = 0; i < outSize; ++i) {
+        const double center = (i + 0.5) * scale;
+
+        int start = static_cast<int>(center - support + 0.5);
+        if (start < 0) start = 0;
+        int end = static_cast<int>(center + support + 0.5);
+        if (end > inSize) end = inSize;
+        const int count = end - start;
+
+        float* w = &coeffs.weights[static_cast<size_t>(i) * coeffs.ksize];
+        double total = 0.0;
+        for (int k = 0; k < count; ++k) {
+            const double x = std::abs((k + start - center + 0.5) * invFilterscale);
+            const double weight = (x < 1.0) ? (1.0 - x) : 0.0;
+            w[k] = static_cast<float>(weight);
+            total += weight;
+        }
+        if (total != 0.0) {
+            for (int k = 0; k < count; ++k) {
+                w[k] = static_cast<float>(w[k] / total);
+            }
+        }
+
+        coeffs.starts[i] = start;
+        coeffs.counts[i] = count;
+    }
+
+    return coeffs;
+}
+
+} // namespace detail
+
+/// @brief Antialiased bilinear resize matching PIL/Pillow (8-bit input)
+/// @param src Source image, CV_8U with any channel count
+/// @param dst Destination image, same type as @p src
+/// @param dstSize Target size
+/// @note Two separable passes with an 8-bit intermediate, exactly like Pillow:
+///       the horizontal result is rounded to bytes before the vertical pass, so
+///       carrying float accumulators across both passes would NOT match.
+inline void resizeAntialiasBilinear(const cv::Mat& src, cv::Mat& dst, const cv::Size& dstSize) {
+    CV_Assert(src.depth() == CV_8U && !src.empty());
+    CV_Assert(dstSize.width > 0 && dstSize.height > 0);
+
+    const int channels = src.channels();
+
+    // Horizontal pass
+    cv::Mat temp;
+    if (src.cols != dstSize.width) {
+        temp.create(src.rows, dstSize.width, src.type());
+        const detail::ResampleCoeffs cx = detail::computeBilinearCoeffs(src.cols, dstSize.width);
+
+        for (int y = 0; y < src.rows; ++y) {
+            const uchar* srcRow = src.ptr<uchar>(y);
+            uchar* dstRow = temp.ptr<uchar>(y);
+
+            for (int x = 0; x < dstSize.width; ++x) {
+                const float* w = &cx.weights[static_cast<size_t>(x) * cx.ksize];
+                const int start = cx.starts[x];
+                const int count = cx.counts[x];
+
+                for (int c = 0; c < channels; ++c) {
+                    double acc = 0.0;
+                    for (int k = 0; k < count; ++k) {
+                        acc += static_cast<double>(w[k]) * srcRow[(start + k) * channels + c];
+                    }
+                    dstRow[x * channels + c] = detail::clip8(acc);
+                }
+            }
+        }
+    } else {
+        temp = src;
+    }
+
+    // Vertical pass
+    if (temp.rows != dstSize.height) {
+        cv::Mat out(dstSize.height, temp.cols, src.type());
+        const detail::ResampleCoeffs cy = detail::computeBilinearCoeffs(temp.rows, dstSize.height);
+
+        for (int y = 0; y < dstSize.height; ++y) {
+            const float* w = &cy.weights[static_cast<size_t>(y) * cy.ksize];
+            const int start = cy.starts[y];
+            const int count = cy.counts[y];
+            uchar* dstRow = out.ptr<uchar>(y);
+
+            // Hoist the contributing row pointers out of the per-pixel loop
+            std::vector<const uchar*> srcRows(static_cast<size_t>(count));
+            for (int k = 0; k < count; ++k) {
+                srcRows[static_cast<size_t>(k)] = temp.ptr<uchar>(start + k);
+            }
+
+            for (int x = 0; x < temp.cols; ++x) {
+                for (int c = 0; c < channels; ++c) {
+                    const int offset = x * channels + c;
+                    double acc = 0.0;
+                    for (int k = 0; k < count; ++k) {
+                        acc += static_cast<double>(w[k]) * srcRows[static_cast<size_t>(k)][offset];
+                    }
+                    dstRow[offset] = detail::clip8(acc);
+                }
+            }
+        }
+        dst = out;
+    } else {
+        dst = temp.clone();  // temp may alias src, so never hand back a view
+    }
+}
+
 } // namespace preprocessing
 } // namespace yolos

--- a/include/yolos/tasks/classification.hpp
+++ b/include/yolos/tasks/classification.hpp
@@ -13,6 +13,8 @@
 #include <onnxruntime_cxx_api.h>
 
 #include <algorithm>
+#include <cmath>
+#include <cstring>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -25,6 +27,7 @@
 
 #include "yolos/core/version.hpp"
 #include "yolos/core/utils.hpp"
+#include "yolos/core/preprocessing.hpp"
 
 namespace yolos {
 namespace cls {
@@ -233,6 +236,11 @@ protected:
     }
 
     /// @brief Preprocess image for classification (Ultralytics-style)
+    ///
+    /// Mirrors ultralytics.data.augment.classify_transforms(), which is
+    ///     T.Resize(size, BILINEAR) -> T.CenterCrop(size) -> T.ToTensor()
+    ///       -> T.Normalize(mean=0, std=1)   [a no-op]
+    /// applied to a PIL image.
     void preprocess(const cv::Mat& image, std::vector<int64_t>& inputTensorShape) {
         int targetSize = inputImageShape_.width;
         int h = image.rows;
@@ -252,12 +260,17 @@ protected:
         cv::Mat rgbImage;
         cv::cvtColor(image, rgbImage, cv::COLOR_BGR2RGB);
 
+        // Ultralytics resizes through PIL, whose BILINEAR filter antialiases.
+        // cv::resize(INTER_LINEAR) does not, which inflated confidences and could
+        // flip the top-1 class relative to Ultralytics (issue #137).
         cv::Mat resized;
-        cv::resize(rgbImage, resized, cv::Size(newW, newH), 0, 0, cv::INTER_LINEAR);
+        preprocessing::resizeAntialiasBilinear(rgbImage, resized, cv::Size(newW, newH));
 
-        // Center crop to target_size x target_size
-        int yStart = std::max(0, (newH - targetSize) / 2);
-        int xStart = std::max(0, (newW - targetSize) / 2);
+        // Center crop to target_size x target_size.
+        // torchvision uses int(round(diff / 2.0)); Python's round() breaks ties to
+        // even, which is what std::nearbyint does under the default rounding mode.
+        int yStart = std::max(0, static_cast<int>(std::nearbyint((newH - targetSize) / 2.0)));
+        int xStart = std::max(0, static_cast<int>(std::nearbyint((newW - targetSize) / 2.0)));
         cv::Mat cropped = resized(cv::Rect(xStart, yStart, targetSize, targetSize));
 
         // Normalize to [0, 1]

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -148,8 +148,9 @@ endif()
 if(testTask STREQUAL "1" OR testTask STREQUAL "5")
     add_executable(inference_classification_cpp 
         ${classification_path}/inference_classification_cpp.cpp)
-    add_executable(compare_classification_results 
-        ${classification_path}/compare_results.cpp)
+    add_executable(compare_classification_results
+        ${classification_path}/compare_results.cpp
+        ${classification_path}/test_preprocessing.cpp)
     
     list(APPEND INFERENCE_EXES inference_classification_cpp)
     list(APPEND TEST_EXES compare_classification_results)

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,7 +7,7 @@ Comprehensive test suite validating C++ YOLO implementations against Python Ultr
 | Task | Tests | Models | Status |
 |------|-------|--------|--------|
 | Detection | 8/8 | YOLOv5, v6, v8, v9, v10, v11, v12, YOLO26 | ✅ Pass |
-| Classification | 6/6 | YOLOv8, v11, YOLO26 | ✅ Pass |
+| Classification | 6/6 parity + 7 preprocessing | YOLOv8, v11, YOLO26 | ✅ Pass |
 | Pose | 7/7 | YOLOv8, v11, YOLO26 | ✅ Pass |
 | Segmentation | 8/8 | YOLOv8, v11, YOLO26 | ✅ Pass |
 | OBB | 7/7 | YOLOv8, v11, YOLO26 | ✅ Pass |
@@ -123,6 +123,13 @@ The test scripts are designed for CI/CD pipelines:
 1. **Model size**: Uses smaller input (320x320) for faster testing
 2. **YOLO26 models**: Feature end-to-end NMS-free architecture
 3. **VOC dataset**: Detection models are fine-tuned on Pascal VOC (20 classes)
+5. **Classification preprocessing**: `inference_classification_ultralytics.py` calls
+   `ultralytics.data.augment.classify_transforms()` for the reference tensor, so the
+   comparison is against Ultralytics itself. It previously re-implemented the C++ OpenCV
+   preprocessing, which meant the suite compared YOLOs-CPP against a Python transcription
+   of itself and could not detect a mismatch (issue #137). `classification/test_preprocessing.cpp`
+   additionally pins the antialiased resize to golden Pillow output, so it is guarded even
+   without a Python run.
 4. **YOLOE**: `tests/yoloe/inference_config.json` lists the same `classes` as `models/export_yoloe_test_onnx.py` and C++ `YOLOESegDetector`. Python reference uses the exported ONNX (no `set_classes` on ONNX). Inference enumerates images in **sorted** order so JSON matches C++. C++ tests bundle ONNX Runtime 1.20.x; Ultralytics may install a different Python `onnxruntime` for ONNX inference—outputs should still match within tolerances.
 
 ## Troubleshooting

--- a/tests/classification/compare_results.cpp
+++ b/tests/classification/compare_results.cpp
@@ -10,7 +10,12 @@
 
 using json = nlohmann::json;
 
-constexpr double CONF_ERROR_MARGIN = 0.1; // +-0.1 difference allowed in confidence scores
+// Measured residual against Ultralytics after the antialiased-resize fix (#137)
+// is <= 0.004: the preprocessed tensors differ by at most 1/255 on a fraction of
+// pixels (Pillow accumulates in fixed point, we accumulate in floating point),
+// plus ~1e-5 from the Python and C++ ONNX Runtime builds differing. The old
+// margin of 0.1 was loose enough to hide preprocessing mismatches of 0.12-0.22.
+constexpr double CONF_ERROR_MARGIN = 0.02;
 
 json read_json(const std::string& path) {
     std::ifstream f(path);

--- a/tests/classification/inference_classification_ultralytics.py
+++ b/tests/classification/inference_classification_ultralytics.py
@@ -1,6 +1,15 @@
 """
-Classification inference using ONNX Runtime with OpenCV preprocessing.
-Matches C++ implementation exactly for fair comparison.
+Classification ground truth using Ultralytics' own preprocessing.
+
+The reference tensor comes from ultralytics.data.augment.classify_transforms(),
+i.e. torchvision T.Resize(size, BILINEAR) -> T.CenterCrop(size) -> T.ToTensor()
+-> T.Normalize(mean=0, std=1), applied to a PIL image. PIL's bilinear filter is
+antialiased, so this is NOT the same as cv2.resize(INTER_LINEAR).
+
+That distinction matters: an earlier version of this script re-implemented the
+C++ OpenCV preprocessing instead, which meant the suite compared YOLOs-CPP
+against a Python transcription of itself and could not detect a mismatch with
+Ultralytics (issue #137).
 """
 import sys
 import os
@@ -9,8 +18,14 @@ import json
 import cv2
 import numpy as np
 import onnxruntime as ort
+from PIL import Image
 from typing import Union
 from tqdm.auto import tqdm
+
+try:
+    from ultralytics.data.augment import classify_transforms
+except ImportError:  # pragma: no cover - the test runner installs ultralytics
+    classify_transforms = None
 
 
 def validate_paths(paths: dict) -> bool:
@@ -41,50 +56,39 @@ def validate_paths(paths: dict) -> bool:
 
 def preprocess_image(image_path: str, target_size: int = 224) -> np.ndarray:
     """
-    Preprocess image using OpenCV to match C++ implementation exactly.
-    - Load BGR
-    - Convert to RGB
-    - Resize shortest side to target_size (using integer division like C++)
-    - Center crop to target_size x target_size
-    - Normalize to [0, 1]
-    - Convert to CHW format
+    Preprocess an image exactly as Ultralytics does for classification.
+
+    Uses ultralytics' own classify_transforms() when available so the reference
+    cannot drift from the library under test. The fallback reproduces the same
+    torchvision pipeline with PIL directly, for environments without torch.
     """
-    # Load image
-    img = cv2.imread(image_path)
-    if img is None:
+    bgr = cv2.imread(image_path)
+    if bgr is None:
         raise ValueError(f"Failed to load image: {image_path}")
-    
-    h, w = img.shape[:2]
-    
-    # Resize: shortest side to target_size, using integer division (C++ style)
-    if h < w:
-        new_h = target_size
-        new_w = (w * target_size) // h  # Integer division to match C++
-    else:
-        new_w = target_size
-        new_h = (h * target_size) // w
-    
-    # Convert BGR to RGB
-    rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
-    
-    # Resize
-    resized = cv2.resize(rgb, (new_w, new_h), interpolation=cv2.INTER_LINEAR)
-    
-    # Center crop
-    y_start = max(0, (new_h - target_size) // 2)
-    x_start = max(0, (new_w - target_size) // 2)
-    cropped = resized[y_start:y_start+target_size, x_start:x_start+target_size]
-    
-    # Normalize to [0, 1]
-    normalized = cropped.astype(np.float32) / 255.0
-    
-    # Convert HWC to CHW
-    chw = np.transpose(normalized, (2, 0, 1))
-    
-    # Add batch dimension
-    batch = np.expand_dims(chw, 0)
-    
-    return batch
+
+    pil = Image.fromarray(cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB))
+
+    if classify_transforms is not None:
+        arr = classify_transforms(size=target_size)(pil).unsqueeze(0).numpy()
+        assert arr.dtype == np.float32, f"expected float32 tensor, got {arr.dtype}"
+        return arr
+
+    # torchvision T.Resize(int): shortest edge -> target_size, aspect preserved
+    w, h = pil.size
+    short, long_ = (w, h) if w <= h else (h, w)
+    new_short, new_long = target_size, int(target_size * long_ / short)
+    new_w, new_h = (new_short, new_long) if w <= h else (new_long, new_short)
+    pil = pil.resize((new_w, new_h), Image.BILINEAR)  # antialiased, like PIL
+
+    # torchvision T.CenterCrop(int): offsets are int(round(diff / 2))
+    top = int(round((new_h - target_size) / 2.0))
+    left = int(round((new_w - target_size) / 2.0))
+    arr = np.asarray(pil)[top:top + target_size, left:left + target_size]
+
+    chw = np.transpose(arr.astype(np.float32) / 255.0, (2, 0, 1))
+    out = np.expand_dims(chw, 0)
+    assert out.dtype == np.float32, f"expected float32 tensor, got {out.dtype}"
+    return out
 
 
 def run_inference(model_path: str, images_path: str) -> list:
@@ -115,7 +119,7 @@ def run_inference(model_path: str, images_path: str) -> list:
         returned_results.append(image_results)
 
         try:
-            # Preprocess using OpenCV (matches C++ exactly)
+            # Preprocess exactly as Ultralytics does
             input_tensor = preprocess_image(image_path, target_size)
             
             # Run inference

--- a/tests/classification/test_preprocessing.cpp
+++ b/tests/classification/test_preprocessing.cpp
@@ -1,0 +1,180 @@
+/**
+ * @file test_preprocessing.cpp
+ * @brief Self-contained tests for the PIL-compatible antialiased resize
+ *
+ * Ultralytics preprocesses classification images with torchvision's
+ * T.Resize(size, BILINEAR) on a PIL image, whose bilinear filter is
+ * antialiased. cv::resize(INTER_LINEAR) is not, which made YOLOs-CPP
+ * confidences disagree with Ultralytics and could flip the top-1 class
+ * (issue #137).
+ *
+ * The expected values below were produced by Pillow itself:
+ *
+ *   PIL.Image.fromarray(src).resize((w, h), PIL.Image.BILINEAR)
+ *
+ * on the deterministic source built by makeSource(). These tests need no model
+ * and no Python, so they guard the resize even when the Ultralytics parity run
+ * is unavailable.
+ */
+
+#include <gtest/gtest.h>
+
+#include <opencv2/opencv.hpp>
+
+#include <string>
+#include <vector>
+
+#include "yolos/core/preprocessing.hpp"
+
+namespace {
+
+constexpr int kSrcW = 13;
+constexpr int kSrcH = 9;
+
+/// @brief Deterministic RGB source, identical to the Python generator
+cv::Mat makeSource() {
+    cv::Mat src(kSrcH, kSrcW, CV_8UC3);
+    for (int y = 0; y < kSrcH; ++y) {
+        for (int x = 0; x < kSrcW; ++x) {
+            src.at<cv::Vec3b>(y, x) = cv::Vec3b(
+                static_cast<uchar>((x * 37 + y * 11) % 256),
+                static_cast<uchar>((x * 5 + y * 61) % 256),
+                static_cast<uchar>((x * y * 17 + 3) % 256));
+        }
+    }
+    return src;
+}
+
+// ---- Pillow reference output -------------------------------------------------
+
+// kGolden5x4: 13x9 -> 5x4
+const std::vector<uchar> kGolden5x4 = {
+    48, 56, 18, 133, 68, 50, 151, 81, 83, 73, 94, 81, 158, 106, 106, 70, 169, 54, 155, 140, 
+    120, 150, 142, 120, 95, 155, 115, 180, 167, 112, 96, 122, 84, 178, 93, 105, 101, 94, 103, 
+    121, 107, 112, 200, 119, 158, 118, 186, 94, 172, 184, 127, 78, 125, 124, 143, 129, 130, 
+    166, 141, 133
+};
+
+// kGolden13x4: 13x9 -> 13x4
+const std::vector<uchar> kGolden13x4 = {
+    9, 51, 3, 46, 56, 17, 83, 61, 31, 120, 66, 45, 157, 71, 59, 194, 76, 73, 231, 81, 88, 12, 
+    86, 102, 49, 91, 64, 86, 96, 79, 123, 101, 93, 160, 106, 107, 197, 111, 121, 31, 168, 3, 
+    68, 173, 52, 105, 178, 100, 142, 127, 142, 179, 132, 135, 216, 137, 77, 191, 142, 119, 34, 
+    147, 168, 71, 152, 91, 108, 157, 134, 145, 162, 76, 182, 167, 125, 219, 172, 117, 57, 120, 
+    3, 94, 125, 90, 131, 130, 178, 168, 79, 72, 205, 84, 103, 223, 89, 97, 29, 94, 78, 60, 99, 
+    147, 97, 104, 110, 134, 109, 72, 171, 114, 154, 208, 119, 154, 226, 124, 185, 79, 181, 3, 
+    116, 186, 125, 153, 191, 152, 190, 196, 113, 227, 201, 140, 59, 111, 101, 45, 116, 127, 82, 
+    121, 140, 119, 126, 115, 156, 131, 127, 193, 136, 154, 230, 141, 115, 62, 146, 142
+};
+
+// kGolden5x9: 13x9 -> 5x9
+const std::vector<uchar> kGolden5x9 = {
+    39, 5, 3, 124, 17, 3, 142, 30, 3, 64, 43, 3, 149, 55, 3, 50, 66, 21, 135, 78, 60, 153, 91, 
+    105, 75, 104, 150, 160, 116, 189, 61, 127, 39, 146, 139, 117, 164, 152, 185, 86, 165, 79, 
+    171, 177, 119, 72, 188, 57, 157, 200, 136, 175, 213, 75, 97, 226, 133, 182, 238, 66, 83, 
+    232, 76, 168, 59, 115, 90, 18, 133, 108, 31, 117, 193, 43, 158, 94, 54, 77, 179, 66, 87, 
+    101, 79, 81, 119, 92, 85, 204, 104, 164, 105, 115, 95, 190, 127, 106, 112, 140, 103, 130, 
+    153, 147, 215, 165, 171, 116, 176, 113, 163, 188, 163, 65, 201, 146, 141, 214, 115, 149, 
+    226, 101, 127, 237, 71, 174, 210, 96, 76, 28, 110, 152, 19, 138, 160, 31, 150
+};
+
+void expectMatchesPillow(const cv::Size& size, const std::vector<uchar>& expected) {
+    cv::Mat out;
+    yolos::preprocessing::resizeAntialiasBilinear(makeSource(), out, size);
+
+    ASSERT_EQ(size.height, out.rows);
+    ASSERT_EQ(size.width, out.cols);
+    ASSERT_EQ(3, out.channels());
+    ASSERT_EQ(expected.size(), out.total() * out.channels());
+
+    size_t i = 0;
+    for (int y = 0; y < out.rows; ++y) {
+        const uchar* row = out.ptr<uchar>(y);
+        for (int x = 0; x < out.cols * 3; ++x, ++i) {
+            ASSERT_EQ(static_cast<int>(expected[i]), static_cast<int>(row[x]))
+                << "mismatch at row " << y << " byte " << x;
+        }
+    }
+}
+
+} // namespace
+
+// ============================================================================
+// Downscaling: the antialiased path
+// ============================================================================
+
+TEST(AntialiasResize, MatchesPillowWhenDownscalingBothAxes) {
+    expectMatchesPillow(cv::Size(5, 4), kGolden5x4);
+}
+
+TEST(AntialiasResize, MatchesPillowWhenDownscalingHeightOnly) {
+    expectMatchesPillow(cv::Size(13, 4), kGolden13x4);
+}
+
+TEST(AntialiasResize, MatchesPillowWhenDownscalingWidthOnly) {
+    expectMatchesPillow(cv::Size(5, 9), kGolden5x9);
+}
+
+TEST(AntialiasResize, DiffersFromPlainBilinearWhenDownscaling) {
+    // The whole point of the fix: a non-antialiased resize gives a different
+    // answer, so this guards against silently reverting to cv::resize.
+    const cv::Mat src = makeSource();
+
+    cv::Mat antialiased;
+    yolos::preprocessing::resizeAntialiasBilinear(src, antialiased, cv::Size(5, 4));
+
+    cv::Mat plain;
+    cv::resize(src, plain, cv::Size(5, 4), 0, 0, cv::INTER_LINEAR);
+
+    cv::Mat diff;
+    cv::absdiff(antialiased, plain, diff);
+    EXPECT_GT(cv::sum(diff)[0] + cv::sum(diff)[1] + cv::sum(diff)[2], 0.0);
+}
+
+// ============================================================================
+// Upscaling and identity
+// ============================================================================
+
+TEST(AntialiasResize, DegeneratesToBilinearWhenUpscaling) {
+    // Pillow clamps the filter support to 1.0 when upscaling, so the result is
+    // ordinary bilinear interpolation and must track cv::resize within rounding.
+    const cv::Mat src = makeSource();
+
+    for (const cv::Size size : {cv::Size(39, 27), cv::Size(27, 21), cv::Size(13, 36)}) {
+        cv::Mat antialiased;
+        yolos::preprocessing::resizeAntialiasBilinear(src, antialiased, size);
+
+        cv::Mat plain;
+        cv::resize(src, plain, size, 0, 0, cv::INTER_LINEAR);
+
+        cv::Mat diff;
+        cv::absdiff(antialiased, plain, diff);
+        double maxDiff = 0.0;
+        cv::minMaxLoc(diff.reshape(1), nullptr, &maxDiff);
+        EXPECT_LE(maxDiff, 1.0) << "upscale to " << size.width << "x" << size.height;
+    }
+}
+
+TEST(AntialiasResize, SameSizeReturnsAnIndependentCopy) {
+    const cv::Mat src = makeSource();
+
+    cv::Mat out;
+    yolos::preprocessing::resizeAntialiasBilinear(src, out, cv::Size(kSrcW, kSrcH));
+
+    cv::Mat diff;
+    cv::absdiff(src, out, diff);
+    EXPECT_EQ(0, cv::countNonZero(diff.reshape(1)));
+    EXPECT_NE(src.data, out.data) << "must not alias the source";
+}
+
+TEST(AntialiasResize, HandlesSingleChannelInput) {
+    cv::Mat gray;
+    cv::cvtColor(makeSource(), gray, cv::COLOR_BGR2GRAY);
+
+    cv::Mat out;
+    yolos::preprocessing::resizeAntialiasBilinear(gray, out, cv::Size(5, 4));
+
+    EXPECT_EQ(4, out.rows);
+    EXPECT_EQ(5, out.cols);
+    EXPECT_EQ(1, out.channels());
+}


### PR DESCRIPTION
Closes #137.

@imessam was right that "the scores are not the same and should be investigated". Investigated — it's the resize.

## Root cause

Ultralytics preprocesses classification images with `ultralytics.data.augment.classify_transforms()`:

```python
T.Resize(size, BILINEAR) -> T.CenterCrop(size) -> T.ToTensor() -> T.Normalize(mean=0, std=1)
```

applied to a **PIL** image (`ClassificationPredictor.preprocess` wraps each frame in `Image.fromarray`). PIL's `BILINEAR` filter is **antialiased** — its support widens with the downscale factor, so every source pixel contributes. `cv::resize(INTER_LINEAR)` always samples a 2×2 neighborhood and therefore aliases when downscaling.

A second, smaller mismatch: torchvision's `CenterCrop` computes offsets as `int(round(diff / 2.0))`; this code used floor. For odd crop offsets that shifts the crop by one pixel.

## Measured impact

On `tests/classification/data/images/dog_bike_car.jpg` (768×576 → 224), comparing the two preprocessed tensors through the same ONNX Runtime session:

| | preprocessed tensor vs PIL | conf delta | top-1 |
|---|---|---|---|
| **before** | max **76/255**, mean 4.03/255 | **0.12 – 0.22** | `yolo26n-cls` flips |
| **after** | max **1/255**, mean 0.001/255 | **≤ 0.0034** | matches |

The flip is the clearest evidence the old code returned a different *answer*, not just a differently-scaled one:

```
yolo26n-cls.onnx
  ultralytics : top1=248 husky             conf=0.2193
  before      : top1=249 Alaskan Malamute  conf=0.3814   <-- wrong class
  after       : top1=248 husky             conf=0.2201
```

And the crop-rounding half of the fix, isolated on images with an odd crop offset: max **217/255**, 3 class flips across 3 models.

## The fix

`preprocessing::resizeAntialiasBilinear()` reproduces Pillow's algorithm (`src/libImaging/Resample.c`):

- support-scaled triangle filter — `filterscale = max(1, in/out)`, which is what antialiases
- two separable passes with an **8-bit intermediate** between them; Pillow rounds the horizontal result to bytes before the vertical pass, and carrying float accumulators across both would not match
- round-half-up clipping, like Pillow's `clip8()`
- upscaling clamps the support to 1.0 and degenerates to ordinary bilinear, as PIL does

Classification uses it instead of `cv::resize`, and crops with `std::nearbyint` to match Python's round-half-to-even `round()`.

**Detection, segmentation, pose and OBB are deliberately untouched.** Ultralytics' `LetterBox` really does use `cv2.INTER_LINEAR` (`augment.py:1815`), so those paths already matched — this is a classification-only divergence.

## Why the test suite never caught this

`inference_classification_ultralytics.py` did not use Ultralytics. Its docstring said *"Matches C++ implementation exactly for fair comparison"* and it re-implemented the C++ OpenCV preprocessing in Python, then ran raw `onnxruntime`. The suite was comparing YOLOs-CPP against a Python transcription of itself, which is why it reported 6/6 passing the whole time — and why `CONF_ERROR_MARGIN = 0.1` was never exercised.

Fixed in this PR:

- the reference now calls `ultralytics.data.augment.classify_transforms()` directly, so it cannot drift from the library under test (with a PIL fallback for environments without torch)
- `CONF_ERROR_MARGIN` tightened `0.1` → `0.02`: above the measured 0.0034 residual, far below the 0.12–0.22 the bug produced
- new `classification/test_preprocessing.cpp` pins the resize to **golden Pillow output** — bit-exact on the downscale cases — plus the upscale, identity and single-channel paths. 7 tests, no model and no Python required, so the resize stays guarded even when the Ultralytics run is unavailable.

## Verification

- 7 golden tests pass, bit-exact vs Pillow on downscale
- 11 image shapes × 3 real models (`yolov8n-cls`, `yolo11l-cls`, `yolo26n-cls` from this repo's releases): max **1/255** pixel error everywhere, **0** class flips, max conf delta **0.0034**. Shapes covered: landscape, portrait, square, exact-224, 2000×1300, 1200×230, two upscale cases, and two constructed odd-crop cases
- mutation-tested both halves independently — reverting the resize restores max 76/255; reverting the crop rounding restores max 217/255 and 3 flips
- full project builds clean including `BUILD_EXAMPLES=ON`

The residual 1/255 on a small fraction of pixels is Pillow accumulating in fixed point where this implementation accumulates in floating point. Matching bit-for-bit would mean porting Pillow's int16 coefficient quantization; the remaining error is ~4e-4 in confidence, so I stopped here.

## Behavior change

**Existing classification confidences will drop** — e.g. 0.774 → 0.558 on the dog image. The old values were inflated by aliasing; the new ones match Ultralytics. Worth a note in release notes so nobody reads a regression into their dashboards.

## Note for whoever merges

#144 also touches `include/yolos/tasks/classification.hpp` (batch inference + in-memory loading). The overlap is small — that PR refactors `preprocess()` into a `preprocessInto(image, float* dst)` helper, this one changes the resize and crop inside it — so whichever lands second needs a trivial rebase.
