### PR TITLE
fix(core): descale against the padding the letterbox actually applied

### DIFF
--- a/include/yolos/core/preprocessing.hpp
+++ b/include/yolos/core/preprocessing.hpp
@@ -72,8 +72,8 @@ inline void letterBox(const cv::Mat& image,
     }
 
     // Calculate new dimensions after scaling (use round to match Ultralytics)
-    int newUnpadW = static_cast<int>(std::round(image.cols * ratio));
-    int newUnpadH = static_cast<int>(std::round(image.rows * ratio));
+    int newUnpadW = static_cast<int>(std::nearbyint(image.cols * ratio));
+    int newUnpadH = static_cast<int>(std::nearbyint(image.rows * ratio));
 
     // Calculate padding needed to reach the desired shape
     int dw = newShape.width - newUnpadW;
@@ -288,14 +288,14 @@ inline void letterBoxToBlobPtr(const cv::Mat& image,
                                   static_cast<float>(dstW) / srcW);
 
     // Ultralytics uses round() for new dimensions
-    const int newH = static_cast<int>(std::round(srcH * scale));
-    const int newW = static_cast<int>(std::round(srcW * scale));
+    const int newH = static_cast<int>(std::nearbyint(srcH * scale));
+    const int newW = static_cast<int>(std::nearbyint(srcW * scale));
 
     // Ultralytics uses asymmetric padding with -0.1/+0.1 adjustment
     const float dh = (dstH - newH) / 2.0f;
     const float dw = (dstW - newW) / 2.0f;
-    const int padTop = static_cast<int>(std::round(dh - 0.1f));
-    const int padLeft = static_cast<int>(std::round(dw - 0.1f));
+    const int padTop = static_cast<int>(std::nearbyint(dh - 0.1f));
+    const int padLeft = static_cast<int>(std::nearbyint(dw - 0.1f));
 
     // Fill this slice with padding color (normalized)
     const size_t sliceSize = static_cast<size_t>(dstH) * dstW * targetChannels;
@@ -425,8 +425,8 @@ inline void letterBoxToBlob(const cv::Mat& image,
                                   static_cast<float>(dstW) / srcW);
     
     // Ultralytics uses round() for new dimensions
-    int newH = static_cast<int>(std::round(srcH * scale));
-    int newW = static_cast<int>(std::round(srcW * scale));
+    int newH = static_cast<int>(std::nearbyint(srcH * scale));
+    int newW = static_cast<int>(std::nearbyint(srcW * scale));
     
     // For dynamic shape, adjust to stride-aligned minimum size
     if (dynamicShape) {
@@ -441,8 +441,8 @@ inline void letterBoxToBlob(const cv::Mat& image,
     // Ultralytics uses asymmetric padding with -0.1/+0.1 adjustment
     const float dh = (dstH - newH) / 2.0f;
     const float dw = (dstW - newW) / 2.0f;
-    const int padTop = static_cast<int>(std::round(dh - 0.1f));
-    const int padLeft = static_cast<int>(std::round(dw - 0.1f));
+    const int padTop = static_cast<int>(std::nearbyint(dh - 0.1f));
+    const int padLeft = static_cast<int>(std::nearbyint(dw - 0.1f));
     
     // Fill with padding (normalized 114/255)
     constexpr float padNorm = 114.0f / 255.0f;
@@ -507,14 +507,22 @@ inline void getScalePad(const cv::Size& originalSize,
                         float& padY) {
     scale = std::min(static_cast<float>(letterboxSize.height) / originalSize.height,
                      static_cast<float>(letterboxSize.width) / originalSize.width);
-    
-    // Use round() for new dimensions (matches Ultralytics)
-    int newW = static_cast<int>(std::round(originalSize.width * scale));
-    int newH = static_cast<int>(std::round(originalSize.height * scale));
-    
-    // For descaling, use UNROUNDED padding values (matches Ultralytics behavior)
-    padX = (letterboxSize.width - newW) / 2.0f;
-    padY = (letterboxSize.height - newH) / 2.0f;
+
+    // Python round() breaks ties to even; std::nearbyint does the same under the
+    // default rounding mode, std::round does not.
+    const int newW = static_cast<int>(std::nearbyint(originalSize.width * scale));
+    const int newH = static_cast<int>(std::nearbyint(originalSize.height * scale));
+
+    // Return the padding the letterbox ACTUALLY applied, which is an integer:
+    // letterBoxToBlob pads by nearbyint(dw - 0.1). Returning the unrounded dw instead
+    // descales against padding that was never there, biasing every box by up to half a
+    // letterbox pixel - which the gain then magnifies into original-image pixels.
+    // This mirrors ultralytics.utils.ops.scale_boxes():
+    //     pad_x = round((img1_w - round(img0_w * gain)) / 2 - 0.1)
+    const float dw = (letterboxSize.width - newW) / 2.0f;
+    const float dh = (letterboxSize.height - newH) / 2.0f;
+    padX = std::nearbyint(dw - 0.1f);
+    padY = std::nearbyint(dh - 0.1f);
 }
 
 /// @brief Fast coordinate descaling (batch operation)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -139,8 +139,9 @@ set(TEST_EXES)
 if(testTask STREQUAL "0" OR testTask STREQUAL "5")
     add_executable(inference_detection_cpp 
         ${detection_path}/inference_detection_cpp.cpp)
-    add_executable(compare_detection_results 
-        ${detection_path}/compare_results.cpp)
+    add_executable(compare_detection_results
+        ${detection_path}/compare_results.cpp
+        ${detection_path}/test_letterbox_consistency.cpp)
     
     list(APPEND INFERENCE_EXES inference_detection_cpp)
     list(APPEND TEST_EXES compare_detection_results)

--- a/tests/detection/compare_results.cpp
+++ b/tests/detection/compare_results.cpp
@@ -12,7 +12,13 @@
 using json = nlohmann::json;
 
 constexpr double CONF_ERROR_MARGIN = 0.1; // +-0.1 difference allowed in confidence scores
-constexpr int BBOX_ERROR_MARGIN = 50;     // +-50 pixels difference allowed in bounding box coordinates
+// Measured C++ vs Ultralytics box agreement after the getScalePad rounding fix is
+// EXACTLY 0 px across 35 boxes and 7 models; before it, the worst coordinate was 5 px
+// out. The old +-50 px margin was therefore ten times too loose to see the defect it
+// was meant to guard. 3 px leaves room for a 1 px integer-quantisation difference
+// across platforms while still failing on a regression of the size just fixed.
+// Do not loosen this without measuring first and recording why (cf. issue #137).
+constexpr int BBOX_ERROR_MARGIN = 3;
 
 json read_json(const std::string& path) {
     std::ifstream f(path);

--- a/tests/detection/test_letterbox_consistency.cpp
+++ b/tests/detection/test_letterbox_consistency.cpp
@@ -1,0 +1,142 @@
+/**
+ * @file test_letterbox_consistency.cpp
+ * @brief Pins the letterbox forward/inverse contract in yolos::preprocessing
+ *
+ * Detection, segmentation, pose and OBB all letterbox with letterBoxToBlob() and then
+ * descale their outputs with getScalePad(). Those two must agree about where the image
+ * was placed. They did not: letterBoxToBlob padded by an integer nearbyint(dw - 0.1)
+ * while getScalePad returned the unrounded dw, so every box was descaled against
+ * padding that had never been applied. The error is up to half a letterbox pixel, which
+ * the gain then magnifies - on a 1600x2128 image at 320 it reached 3.3 original pixels.
+ *
+ * The parity suite could not see it: its tolerance was +-50 px.
+ *
+ * These tests need no model and no Python.
+ */
+
+#include <gtest/gtest.h>
+
+#include <opencv2/opencv.hpp>
+
+#include <cmath>
+#include <vector>
+
+#include "yolos/core/preprocessing.hpp"
+
+namespace {
+
+/// @brief Column at which real image content starts in a letterboxed blob
+/// @param blob CHW blob produced by letterBoxToBlob
+/// @param size Letterbox size
+/// @return First column whose value differs from the 114/255 padding fill
+int firstContentColumn(const std::vector<float>& blob, const cv::Size& size) {
+    constexpr float padNorm = 114.0f / 255.0f;
+    const int row = size.height / 2;
+    for (int x = 0; x < size.width; ++x) {
+        if (std::abs(blob[static_cast<size_t>(row) * size.width + x] - padNorm) > 0.05f) {
+            return x;
+        }
+    }
+    return -1;
+}
+
+/// @brief Row at which real image content starts in a letterboxed blob
+int firstContentRow(const std::vector<float>& blob, const cv::Size& size) {
+    constexpr float padNorm = 114.0f / 255.0f;
+    const int col = size.width / 2;
+    for (int y = 0; y < size.height; ++y) {
+        if (std::abs(blob[static_cast<size_t>(y) * size.width + col] - padNorm) > 0.05f) {
+            return y;
+        }
+    }
+    return -1;
+}
+
+} // namespace
+
+// ============================================================================
+// getScalePad must report the padding letterBoxToBlob actually applied
+// ============================================================================
+
+TEST(LetterboxConsistency, ScalePadMatchesAppliedPadding) {
+    // Each pair is (source size, letterbox size). The odd cases are the ones that used
+    // to break: when (target - resized) is odd, dw lands on .5 and the applied integer
+    // pad and the returned float pad diverged.
+    const std::vector<std::pair<cv::Size, cv::Size>> cases = {
+        {cv::Size(640, 480), cv::Size(640, 640)},    // even vertical pad
+        {cv::Size(480, 640), cv::Size(640, 640)},    // even horizontal pad
+        {cv::Size(481, 640), cv::Size(640, 640)},    // ODD horizontal pad (dw = 79.5)
+        {cv::Size(640, 481), cv::Size(640, 640)},    // ODD vertical pad
+        {cv::Size(1600, 2128), cv::Size(320, 320)},  // ODD, small gain: the 3.3 px case
+        {cv::Size(302, 329), cv::Size(320, 320)},    // a real test image's shape
+        {cv::Size(1280, 720), cv::Size(640, 640)},
+        {cv::Size(500, 500), cv::Size(640, 640)},    // square, no padding at all
+    };
+
+    for (const auto& [srcSize, boxSize] : cases) {
+        // Black source on the 114-grey pad makes the content boundary unambiguous.
+        const cv::Mat src(srcSize, CV_8UC3, cv::Scalar(0, 0, 0));
+
+        yolos::preprocessing::InferenceBuffer buffer;
+        cv::Size actual;
+        yolos::preprocessing::letterBoxToBlob(src, buffer, 3, boxSize, actual, false);
+        ASSERT_EQ(boxSize, actual);
+
+        float scale = 0.0f;
+        float padX = 0.0f;
+        float padY = 0.0f;
+        yolos::preprocessing::getScalePad(srcSize, boxSize, scale, padX, padY);
+
+        const std::string what = std::to_string(srcSize.width) + "x" +
+                                 std::to_string(srcSize.height) + " -> " +
+                                 std::to_string(boxSize.width) + "x" +
+                                 std::to_string(boxSize.height);
+
+        // Compare as float, not via static_cast<int>: truncating would silently accept
+        // a fractional pad such as 79.5 as "equal to" the applied 79, which is exactly
+        // the bug this test exists to catch.
+        EXPECT_FLOAT_EQ(static_cast<float>(firstContentColumn(buffer.blob, boxSize)), padX)
+            << what << ": getScalePad padX disagrees with the padding actually applied";
+        EXPECT_FLOAT_EQ(static_cast<float>(firstContentRow(buffer.blob, boxSize)), padY)
+            << what << ": getScalePad padY disagrees with the padding actually applied";
+    }
+}
+
+TEST(LetterboxConsistency, ScalePadReturnsWholePixels) {
+    // The letterbox can only pad by whole pixels, so a fractional pad is by definition
+    // a pad that was never applied. This is the invariant the old code violated.
+    float scale = 0.0f;
+    float padX = 0.0f;
+    float padY = 0.0f;
+    yolos::preprocessing::getScalePad(cv::Size(481, 640), cv::Size(640, 640), scale, padX, padY);
+
+    EXPECT_FLOAT_EQ(std::floor(padX), padX) << "padX = " << padX << " is not a whole pixel";
+    EXPECT_FLOAT_EQ(std::floor(padY), padY) << "padY = " << padY << " is not a whole pixel";
+}
+
+// ============================================================================
+// Tie rounding: Python round() breaks ties to even, std::round does not
+// ============================================================================
+
+TEST(LetterboxConsistency, ResizedDimensionBreaksTiesToEven) {
+    // 193x256 letterboxed to 640: the scale is exactly 2.5, so the resized width is
+    // exactly 482.5. Ultralytics' round() gives 482 (ties to even); std::round would
+    // give 483 and place one extra column of image content.
+    const cv::Size srcSize(193, 256);
+    const cv::Size boxSize(640, 640);
+
+    const cv::Mat src(srcSize, CV_8UC3, cv::Scalar(0, 0, 0));
+    yolos::preprocessing::InferenceBuffer buffer;
+    cv::Size actual;
+    yolos::preprocessing::letterBoxToBlob(src, buffer, 3, boxSize, actual, false);
+
+    // 482 wide content leaves (640 - 482) / 2 = 79 columns of padding on each side.
+    EXPECT_EQ(79, firstContentColumn(buffer.blob, boxSize))
+        << "resized width should be 482 (ties to even), not 483";
+
+    float scale = 0.0f;
+    float padX = 0.0f;
+    float padY = 0.0f;
+    yolos::preprocessing::getScalePad(srcSize, boxSize, scale, padX, padY);
+    EXPECT_FLOAT_EQ(79.0f, padX) << "getScalePad must break the same tie the same way";
+}


### PR DESCRIPTION
Fixes the `std::round` divergence in `getScalePad()` and `letterBoxToBlob()` that I flagged while working on #146. Investigating it turned up a second, larger defect in the same function.

## The real bug: descaling against padding that was never applied

`letterBoxToBlob()` pads by an **integer**, `nearbyint(dw - 0.1)`. `getScalePad()` returned the **unrounded** `dw` for the descaler. Whenever `(target - resized)` is odd those disagree by half a letterbox pixel — and the descaler divides by the gain, so the error grows in original-image space. A sweep over 9,222 shapes: **17% of axes affected, up to 3.33 original pixels.**

The old comment said the unrounded value "matches Ultralytics behavior". It does not, and that is why this survived. Current upstream `ops.scale_boxes()` descales with:

```python
pad_x = round((img1_shape[1] - round(img0_shape[1] * gain)) / 2 - 0.1)
```

— the same integer pad its `LetterBox` applied. The fix makes `getScalePad` do that.

### Measured against Ultralytics

YOLOv8n-VOC on a 1600×2128 image (gain 0.150, `dw` = 39.5, the worst case from the sweep):

| | mean \|Δ\| | max \|Δ\| | per-edge x1,y1,x2,y2 |
|---|---|---|---|
| **before** | 2.334 px | 3.846 px | 3.589, 0.590, 3.726, 1.431 |
| **after** | **0.834 px** | **1.566 px** | 0.589, 0.590, 0.726, 1.431 |

The **x** edges — the axis with the odd pad — drop from ~3.6 px to ~0.6 px, the same floor as **y**, which had an even pad and was already correct. The remaining ~0.8 px is integer box quantisation: this library returns `int` box coordinates, Ultralytics returns floats. An even-pad image (`dog_bike_car.jpg`) is byte-identical before and after, as it should be.

On the detection parity images the worst coordinate goes from **5 px to exactly 0 px** across 35 boxes and 7 models.

## The tie rounding, as originally reported

Python's `round()` breaks ties to even; `std::round` rounds half away from zero. When a scaled dimension lands exactly on `.5` the two disagree and one extra row or column of image content gets placed. Rare — 1 in 11,622 shapes I swept — but real: 193×256 at 640 scales to exactly 482.5. Replaced with `std::nearbyint` in the live paths.

`letterBoxCentered`, `scaleCoords`, `scaleKeypoint` and `getLetterboxParams` still use `std::round`. **They have zero call sites** — dead code, left alone rather than changed unverifiably.

## Tests

New `tests/detection/test_letterbox_consistency.cpp`, compiled into the existing detection gtest target. No model, no Python:

1. `getScalePad` reports the padding `letterBoxToBlob` actually applied, across 8 shapes including three odd-pad cases.
2. The returned pad is a whole pixel — a fractional pad is by definition one that was never applied.
3. Ties break to even.

**Each was verified to fail against the old code.** Worth noting: my first version of test 1 compared `static_cast<int>(padX)`, which truncates 79.5 → 79 and so *passed* against the buggy code. Mutation testing caught it; it now compares as float.

`BBOX_ERROR_MARGIN` tightened **50 → 3 px**. The measured residual is 0 px and the defect it failed to catch was 5 px, so ±50 was ten times too loose — the same failure mode as #137.

## Verified

All eight suites pass locally with the fix: detection 10, segmentation 8, pose 7, OBB 7, classification 13, YOLOE 8, API 22, depth 32.

## Behaviour change

**Box, mask, keypoint and OBB coordinates move by up to a few pixels** for detection, segmentation, pose and OBB — toward Ultralytics. Anything asserting on exact historical coordinates will need updating. Depth and classification are unaffected in practice (depth descales via `cropLetterboxAndResize`, which was already correct; classification does not letterbox).

## One thing to know

The committed `tests/*/results/*.json` reference files are **stale** relative to current Ultralytics — I measured up to 272 px between the committed reference and a fresh regeneration with 8.4.115. The ±50 px margin hid that too. It does not affect CI or `test_*.sh`, both of which regenerate before comparing, but running `compare_detection_results` standalone against the committed artifacts will now fail at the tighter margin. Worth either regenerating them or dropping them from version control in a follow-up; I left them untouched here rather than mixing version drift into a rounding fix.
